### PR TITLE
Refactor build-release.sh

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,42 @@ bin/build-release.sh storm.zip
 
 This will build a Mesos executor package.  You'll need to edit `storm.yaml` and supply the Mesos master configuration as well as the executor package URI (produced by the step above).
 
+## Sub-commands
+
+Sub-commands can be invoked similar to git sub-commands.
+
+For example the following command will download the Storm release zip into the current working directory.
+```bash
+bin/build-release.sh downloadStormRelease
+```
+
+* `clean`
+
+  Attempts to clean working files and directories created when building.
+
+* `mvnPackage`
+
+  Runs the maven targets necessary to build the Storm Mesos framework.
+
+* `prePackage`
+
+  Prepares the working directories to be able to package the Storm Mesos framework.
+  * Optional argument specifying the Storm release zip to package against.
+
+* `package`
+
+  Packages the Storm Mesos Framework.
+
+* `downloadStormRelease`
+
+  A utility function to download the Storm release zip for the targeted storm release.
+
+  _Set `MIRROR` environment variable to configure download mirror._
+
+* `help`
+
+  Prints out usage information about the build-release.sh script.
+
 # Running Storm on Mesos
 Along with the Mesos master and Mesos cluster, you'll need to run the Storm master as well. Launch Nimbus with this command: 
 

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -1,20 +1,43 @@
 #!/bin/bash
 set -o errexit -o nounset -o pipefail
 
+function _rm {
+  rm -rf "$@" 2>/dev/null || true
+}
 RELEASE=`grep -1 -A 0 -B 0 '<version>' pom.xml | head -n 1 | awk '{print $1}' | sed -e 's/.*<version>//' | sed -e 's/<\/version>.*//'`
 
-RELEASE_ZIP_NAME=apache-storm-${RELEASE}.zip
+MIRROR=${MIRROR:-"http://www.gtlib.gatech.edu/pub"}
 
-MIRROR=http://www.gtlib.gatech.edu/pub
+function help {
+  cat <<USAGE
+Usage: bin/build-release.sh <storm.zip>
+  clean                   Attempts to clean working files and directories
+                            created when building.
+  mvnPackage              Runs the maven targets necessary to build the Storm
+                            Mesos framework.
+  prePackage <storm.zip>  Prepares the working directories to be able to
+                            package the Storm Mesos framework.
+  package                 Packages the Storm Mesos Framework.
+  downloadStormRelease    A utility function to download the Storm release zip
+                            for the targeted storm release.
+
+  ENV
+    MIRROR        Specify Apache Storm Mirror to download from
+                    Default: ${MIRROR}
+    RELEASE       The targeted release version of Storm
+                    Default: ${RELEASE}
+USAGE
+}; function --help { help ;}; function -h { help ;}
+
 function downloadStormRelease {
   wget --progress=dot:mega ${MIRROR}/apache/incubator/storm/apache-storm-${RELEASE}/apache-storm-${RELEASE}.zip
 }
 
 function clean {
-  rm -rf _release || true
-  rm -rf lib/ classes/ || true
-  rm -rf target || true
-  rm -f *mesos*.tgz || true
+  _rm _release
+  _rm lib/ classes/
+  _rm target
+  _rm *mesos*.tgz
 }
 
 function mvnPackage {
@@ -22,18 +45,18 @@ function mvnPackage {
   mvn dependency:copy-dependencies
 }
 
-function release {(
-  rm -rf _release
+function prePackage {(
+  _rm _release
   mkdir -p _release
   cp $1 _release/storm.zip
   cd _release
   unzip storm.zip
-  rm storm.zip
+  _rm storm.zip
   mv apache-storm* storm
 )}
 
 function package {(
-  rm _release/storm/*.jar 2> /dev/null || true
+  _rm _release/storm/*.jar
 
   # copies storm-mesos jar over
   cp target/*.jar _release/storm/lib/
@@ -52,7 +75,7 @@ function package {(
 function main {
   clean
   mvnPackage
-  release ${1:-${RELEASE_ZIP_NAME}}
+  prePackage ${1:-${RELEASE_ZIP_NAME}}
   package
 }
 


### PR DESCRIPTION
I've refactored the build-release.sh script so that there are bash functions representing each of the phases of building the release tar.

By default when the script is ran it will run the `main` function which will run everything the same way the script runs now.

It is now possible to do run `bin/build-release.sh package` to run just the final `tar`ing phase of the build.

I've also added a new function `downloadStormRelease` that can be used to download the storm zip release.
