### PR TITLE
Don't clear all cached offers everytime MesosNimbus receives a new set o...

### DIFF
--- a/src/storm/mesos/MesosNimbus.java
+++ b/src/storm/mesos/MesosNimbus.java
@@ -655,7 +655,6 @@ public class MesosNimbus implements INimbus {
     @Override
     public void resourceOffers(SchedulerDriver driver, List<Offer> offers) {
       synchronized (OFFERS_LOCK) {
-        _offers.clear();
         for (Offer offer : offers) {
           if (_offers != null && isHostAccepted(offer.getHostname())) {
             _offers.put(offer.getId(), offer);


### PR DESCRIPTION
...f offers

The previous behavior prevents accumulating enough offers to launch topologies,
since Mesos doesn't offer *all* resources every time resourceOffers() is called.

We still decline some of the cached offers every 120 seconds by default,
when RotatingMap.rotate() is invoked by a timer, so we don't permanently
hoard offers.