### PR TITLE
Improve logging in MesosNimbus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,9 @@
         <version>1.1</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.4</version>
       </dependency>
       <dependency>
         <groupId>com.googlecode.json-simple</groupId>

--- a/src/storm/mesos/MesosNimbus.java
+++ b/src/storm/mesos/MesosNimbus.java
@@ -23,7 +23,7 @@ import backtype.storm.utils.LocalState;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.protobuf.ByteString;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.log4j.Logger;
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos.*;
@@ -45,6 +45,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import static storm.mesos.PrettyProtobuf.getTrimmedString;
+import static storm.mesos.PrettyProtobuf.offerMapToString;
+import static storm.mesos.PrettyProtobuf.offerToString;
+import static storm.mesos.PrettyProtobuf.taskInfoToString;
+import static storm.mesos.PrettyProtobuf.taskStatusToString;
 
 public class MesosNimbus implements INimbus {
   public static final String CONF_EXECUTOR_URI = "mesos.executor.uri";
@@ -126,12 +132,12 @@ public class MesosNimbus implements INimbus {
       }
 
       Integer port = (Integer) _conf.get(CONF_MESOS_LOCAL_FILE_SERVER_PORT);
-      LOG.info("Using local port: " + port);
       _localFileServerPort = Optional.fromNullable(port);
+      LOG.debug("LocalFileServer configured to listen on port: " + _localFileServerPort);
 
       _httpServer = new LocalFileServer();
       _configUrl = _httpServer.serveDir("/conf", "conf", _localFileServerPort);
-      LOG.info("Started serving config dir under " + _configUrl);
+      LOG.info("Started HTTP server from which config for the MesosSupervisor's may be fetched. URL: " + _configUrl);
 
       MesosSchedulerDriver driver =
           new MesosSchedulerDriver(
@@ -140,9 +146,9 @@ public class MesosNimbus implements INimbus {
               (String) conf.get(CONF_MASTER_URL));
 
       driver.start();
-      LOG.info("Waiting for scheduler to initialize...");
+      LOG.info("Waiting for scheduler driver to register MesosNimbus with mesos-master and complete initialization...");
       _scheduler.waitUntilRegistered();
-      LOG.info("Scheduler initialized...");
+      LOG.info("Scheduler registration and initialization complete...");
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -185,7 +191,7 @@ public class MesosNimbus implements INimbus {
       }
     }
 
-    LOG.debug("Offer: " + offer.toString());
+    LOG.debug("Offer: " + offerToString(offer));
     LOG.debug("Extracted resources: " + resources.toString());
     return resources;
   }
@@ -249,12 +255,14 @@ public class MesosNimbus implements INimbus {
   public Collection<WorkerSlot> allSlotsAvailableForScheduling(
       Collection<SupervisorDetails> existingSupervisors, Topologies topologies, Set<String> topologiesMissingAssignments) {
     synchronized (OFFERS_LOCK) {
-      LOG.info("Currently have " + _offers.size() + " offers buffered");
+      LOG.info("allSlotsAvailableForScheduling: Currently have " + _offers.size() + " offers buffered" +
+          (_offers.size() > 0 ? (":" + offerMapToString(_offers)) : ""));
       if (!topologiesMissingAssignments.isEmpty()) {
         LOG.info("Topologies that need assignments: " + topologiesMissingAssignments.toString());
       } else {
         LOG.info("Declining offers because no topologies need assignments");
         _offers.clear();
+        return new ArrayList<WorkerSlot>();
       }
     }
 
@@ -274,6 +282,9 @@ public class MesosNimbus implements INimbus {
       }
     }
 
+    LOG.info("allSlotsAvailableForScheduling: pending topologies' max resource requirements per worker: cpu: " +
+        String.valueOf(cpu) + " & mem: " + String.valueOf(mem));
+
     List<WorkerSlot> allSlots = new ArrayList<WorkerSlot>();
 
     if (cpu != null && mem != null) {
@@ -283,6 +294,9 @@ public class MesosNimbus implements INimbus {
           List<WorkerSlot> offerSlots = toSlots(offer, cpu, mem, _supervisorExists);
           if(offerSlots.isEmpty()) {
             _offers.clearKey(offer.getId());
+            LOG.info("Declining offer `" + offerToString(offer) + "' because it wasn't " +
+                "usable to create a slot which fits largest pending topologies' aggregate needs " +
+                "(max cpu: " + String.valueOf(cpu) + " max mem: " + String.valueOf(mem) + ")");
           } else {
             allSlots.addAll(offerSlots);
           }
@@ -291,6 +305,11 @@ public class MesosNimbus implements INimbus {
     }
 
     LOG.info("Number of available slots: " + allSlots.size());
+    if (LOG.isDebugEnabled()) {
+      for (WorkerSlot slot : allSlots) {
+        LOG.debug("available slot: " + slot);
+      }
+    }
     return allSlots;
   }
 
@@ -336,6 +355,19 @@ public class MesosNimbus implements INimbus {
 
   @Override
   public void assignSlots(Topologies topologies, Map<String, Collection<WorkerSlot>> slots) {
+    if (slots.size() == 0) {
+      LOG.info("assignSlots: no slots passed in, nothing to do");
+      return;
+    }
+    for (Map.Entry<String, Collection<WorkerSlot>> topologyToSlots : slots.entrySet()) {
+      String topologyId = topologyToSlots.getKey();
+      for (WorkerSlot slot : topologyToSlots.getValue()) {
+        TopologyDetails details = topologies.getById(topologyId);
+        LOG.info("assignSlots: topologyId: " + topologyId + " worker being assigned to slot: " + slot +
+               " with workerCpu: " + MesosCommon.topologyWorkerCpu(_conf, details) +
+               " workerMem: " + MesosCommon.topologyWorkerMem(_conf, details));
+      }
+    }
     synchronized (OFFERS_LOCK) {
       Map<OfferID, List<LaunchTask>> toLaunch = new HashMap<>();
       for (String topologyId : slots.keySet()) {
@@ -553,7 +585,7 @@ public class MesosNimbus implements INimbus {
         List<LaunchTask> tasks = toLaunch.get(id);
         List<TaskInfo> launchList = new ArrayList<>();
 
-        LOG.info("Launching tasks for offer " + id.getValue() + "\n" + tasks.toString());
+        LOG.info("Launching tasks for offerId: " + getTrimmedString(id) + ":" + launchTaskListToString(tasks));
         for (LaunchTask t : tasks) {
           launchList.add(t.task);
           used_offers.put(t.task.getTaskId(), t.offer);
@@ -655,18 +687,24 @@ public class MesosNimbus implements INimbus {
     @Override
     public void resourceOffers(SchedulerDriver driver, List<Offer> offers) {
       synchronized (OFFERS_LOCK) {
+        LOG.info("resourceOffers: Currently have " + _offers.size() + " offers buffered" +
+            (_offers.size() > 0 ? (":" + offerMapToString(_offers)) : ""));
         for (Offer offer : offers) {
           if (_offers != null && isHostAccepted(offer.getHostname())) {
+            LOG.info("resourceOffers: Recording offer from host: " + offer.getHostname() + ", offerId: " + getTrimmedString(offer.getId()));
             _offers.put(offer.getId(), offer);
           } else {
+            LOG.info("resourceOffers: Declining offer from host: " + offer.getHostname() + ", offerId: " + getTrimmedString(offer.getId()));
             driver.declineOffer(offer.getId());
           }
         }
+        LOG.debug("resourceOffers: After processing offers, now have " + _offers.size() + " offers buffered:" + offerMapToString(_offers));
       }
     }
 
     @Override
     public void offerRescinded(SchedulerDriver driver, OfferID id) {
+      LOG.info("Offer rescinded. offerId: " + getTrimmedString(id));
       synchronized (OFFERS_LOCK) {
         _offers.remove(id);
       }
@@ -674,7 +712,7 @@ public class MesosNimbus implements INimbus {
 
     @Override
     public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
-      LOG.info("Received status update: " + status.toString());
+      LOG.info("Received status update: " + taskStatusToString(status));
       switch (status.getState()) {
         case TASK_FINISHED:
         case TASK_FAILED:
@@ -699,12 +737,13 @@ public class MesosNimbus implements INimbus {
 
     @Override
     public void slaveLost(SchedulerDriver driver, SlaveID id) {
-      LOG.info("Lost slave: " + id.toString());
+      LOG.warn("Lost slave id: " + getTrimmedString(id));
     }
 
     @Override
     public void executorLost(SchedulerDriver driver, ExecutorID executor, SlaveID slave, int status) {
-      LOG.info("Executor lost: executor=" + executor + " slave=" + slave);
+      LOG.info("Executor lost: executor: " + getTrimmedString(executor) +
+          " slave: " + getTrimmedString(slave) + " status: " + status);
     }
   }
 
@@ -716,5 +755,19 @@ public class MesosNimbus implements INimbus {
       this.task = task;
       this.offer = offer;
     }
+
+    @Override
+    public String toString() {
+      return "Offer: " + offerToString(offer) + " TaskInfo: " + taskInfoToString(task);
+    }
+  }
+
+  private static String launchTaskListToString(List<LaunchTask> launchTasks) {
+    StringBuilder sb = new StringBuilder(1024);
+    for (LaunchTask launchTask : launchTasks) {
+      sb.append("\n");
+      sb.append(launchTask.toString());
+    }
+    return sb.toString();
   }
 }

--- a/src/storm/mesos/PrettyProtobuf.java
+++ b/src/storm/mesos/PrettyProtobuf.java
@@ -1,0 +1,258 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package storm.mesos;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.mesos.Protos.ExecutorID;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.SlaveID;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.TaskState;
+import org.apache.mesos.Protos.TaskStatus;
+import org.apache.mesos.Protos.Value.Range;
+import org.json.simple.JSONValue;
+
+
+/**
+ * This utility class provides methods to improve logging of Mesos protobuf objects.
+ * These methods don't perform any logging directly, instead they return Strings
+ * which can be logged by callers.
+ *
+ * The methods offer more concise and readable String representations of protobuf
+ * objects than you get by calling a protobuf object's native toString method.
+ *
+ * Another advantage over standard protobuf toString() output is that this output is
+ * in proper JSON format, resulting in logs that can be more easily parsed.
+ *
+ * TODO(erikdw):
+ *  1. Check whether a value is set/null when deciding whether to include it.
+ *  2. Currently we only include the object values that we care about for a
+ *     storm-only mesos-cluster.  We should instead allow configuration for choosing
+ *     which fields to include (e.g., a bitmap toggling certain fields on/off).
+ *  3. Allow cleanly logging to separate Logger, to allow configuring the logs going to
+ *     a separate log file.  The complication is that these methods lack context,
+ *     they are just pretty-printing the protobuf objects.
+ */
+public class PrettyProtobuf {
+
+  /**
+   * Ideally we'd have a generic method for these getTrimmedString methods, but
+   * these protobuf types don't implement a common interface (which would need
+   * to include getValue()).
+   */
+
+  /**
+   * Pretty-print the mesos protobuf OfferID.
+   */
+  public static String getTrimmedString(OfferID id) {
+    return id.getValue().toString().trim();
+  }
+
+  /**
+   * Pretty-print the mesos protobuf SlaveID.
+   */
+  public static String getTrimmedString(SlaveID id) {
+    return id.getValue().toString().trim();
+  }
+
+  /**
+   * Pretty-print the mesos protobuf ExecutorID.
+   */
+  public static String getTrimmedString(ExecutorID id) {
+    return id.getValue().toString().trim();
+  }
+
+  /**
+   * Pretty-print the mesos protobuf TaskID.
+   */
+  public static String getTrimmedString(TaskID id) {
+    return id.getValue().toString().trim();
+  }
+
+  /**
+   * Pretty-print the mesos protobuf TaskState.
+   */
+  public static String getTrimmedString(TaskState state) {
+    return state.toString().trim();
+  }
+
+  /**
+   * Pretty-print mesos protobuf TaskStatus.
+   */
+  public static String taskStatusToString(TaskStatus taskStatus) {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("task_id", getTrimmedString(taskStatus.getTaskId()));
+    map.put("slave_id", getTrimmedString(taskStatus.getSlaveId()));
+    map.put("state", getTrimmedString(taskStatus.getState()));
+    return JSONValue.toJSONString(map);
+  }
+
+  /**
+   * Pretty-print mesos protobuf TaskInfo.
+   *
+   * XXX(erikdw): not including command, container (+data), nor health_check.
+   */
+  public static String taskInfoToString(TaskInfo task) {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("task_id", getTrimmedString(task.getTaskId()));
+    map.put("slave_id", getTrimmedString(task.getSlaveId()));
+    map.putAll(resourcesToOrderedMap(task.getResourcesList()));
+    map.put("executor_id", getTrimmedString(task.getExecutor().getExecutorId()));
+    return JSONValue.toJSONString(map);
+  }
+
+  /**
+   * Pretty-print mesos protobuf Offer.
+   *
+   * XXX(erikdw): not including slave_id, attributes, executor_ids, nor framework_id.
+   */
+  public static String offerToString(Offer offer) {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("offer_id", getTrimmedString(offer.getId()));
+    map.put("hostname", offer.getHostname());
+    map.putAll(resourcesToOrderedMap(offer.getResourcesList()));
+    return JSONValue.toJSONString(map);
+  }
+
+  /**
+   * Pretty-print List of mesos protobuf Offers.
+   */
+  public static String offerListToString(List<Offer> offers) {
+    List<String> offersAsStrings = Lists.transform(offers, offerToStringTransform);
+    return "[\n" + StringUtils.join(offersAsStrings, ",\n") + "]";
+  }
+
+  /**
+   * Pretty-print List of mesos protobuf TaskInfos.
+   */
+  public static String taskInfoListToString(List<TaskInfo> tasks) {
+    List<String> tasksAsStrings = Lists.transform(tasks, taskInfoToStringTransform);
+    return "[\n" + StringUtils.join(tasksAsStrings, ",\n") + "]";
+  }
+
+  /**
+   * Pretty-print the values in the Offer map used in MesosNimbus.
+   *
+   * Callers must ensure they have locked the Map first, else they could
+   * have inconsistent output since the _offers map is touched from both
+   * mesos-driven events and storm-driven calls.
+   *
+   * FIXME(erikdw): figure out a design better that removes the need
+   * for external callers to lock before calling this method.
+   */
+  public static String offerMapToString(RotatingMap<OfferID, Offer> offers) {
+    List<String> offersAsStrings = Lists.transform(new ArrayList<Offer>(offers.values()),
+        offerToStringTransform);
+    return "[\n" + StringUtils.join(offersAsStrings, ",\n") + "]";
+  }
+
+  /**
+   * Wrapper around offerToString which allows using gauva's transform utility.
+   */
+  private static Function<Offer, String> offerToStringTransform =
+      new Function<Offer,String>() {
+        public String apply(Offer o) { return offerToString(o); }
+      };
+
+  /**
+   * Wrapper around taskInfoToString which allows using gauva's transform utility.
+   */
+  private static Function<TaskInfo, String> taskInfoToStringTransform =
+      new Function<TaskInfo,String>() {
+        public String apply(TaskInfo t) { return taskInfoToString(t); }
+      };
+
+  /**
+   * Wrapper around rangeToString which allows using gauva's transform utility.
+   */
+  private static Function<Range, String> rangeToStringTransform =
+      new Function<Range,String>() {
+        public String apply(Range r) { return rangeToString(r); }
+      };
+
+  /**
+   * Create String representation of mesos protobuf Range type.
+   */
+  private static String rangeToString(Range range) {
+    String beginStr = String.valueOf(range.getBegin());
+    String endStr = String.valueOf(range.getEnd());
+    /*
+     * A Range representing a single number still has both Range.begin
+     * and Range.end populated, but they are set to the same value.
+     * In that case we just return "N" instead of "N-N".
+     */
+    if (range.getBegin() == range.getEnd()) {
+      return beginStr;
+    } else {
+      return beginStr + "-" + endStr;
+    }
+  }
+
+  /**
+   * Pretty-print List of mesos protobuf Ranges.
+   */
+  private static String rangeListToString(List<Range> ranges) {
+    List<String> rangesAsStrings = Lists.transform(ranges, rangeToStringTransform);
+    return "[" + StringUtils.join(rangesAsStrings, ",") + "]";
+  }
+
+  /**
+   * Construct a Map of Resource names to String values.
+   * Ensure the order is always the same (cpu, mem, then ports), so that
+   * we have consistently ordered log output.
+   */
+  private static Map<String, String> resourcesToOrderedMap(List<Resource> resources) {
+    String cpus = null, mem = null, ports = null;
+    for (Resource r : resources) {
+      switch (r.getName()) {
+        case "cpus":
+          cpus = String.valueOf(r.getScalar().getValue());
+          break;
+        case "mem":
+          mem = String.valueOf(r.getScalar().getValue());
+          break;
+        case "ports":
+          ports = rangeListToString(r.getRanges().getRangeList());
+          break;
+      }
+    }
+    Map<String, String> map = new LinkedHashMap<>();
+    if (cpus != null) {
+      map.put("cpus", cpus);
+    }
+    if (mem != null) {
+      map.put("mem", mem);
+    }
+    if (ports != null) {
+      map.put("ports", ports);
+    }
+    return map;
+  }
+
+}


### PR DESCRIPTION
The original logging done in MesosNimbus has a high signal-to-noise
ratio due to using standard Protobuf toString methods.

This change is largely about pulling out important information from the
Protobuf objects and then printing the info in a more condensed format,
using JSON for any objects that have multiple internal fields.
This allows us to print more information in many less lines than before.

The goal is to allow introspecting the behavior of the MesosNimbus,
especially with respect to its handling of Offers and interactions with
the core nimbus code thru the INimbus interface methods.

Also did some minor clean up of various log lines in MesosNimbus.