### PR TITLE
Added logviewer startup from supervisor

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -109,7 +109,7 @@ Storm/Mesos provides resource isolation between topologies. So you don't need to
 * `mesos.framework.name`: Framework name. Defaults to "Storm!!!".
 * `mesos.framework.principal`: Framework principal to use to register with Mesos
 * `mesos.framework.secret.file`:  Location of file that contains the principal's secret. Secret cannot end with a NL.
-
+* `supervisor.autostart.logviewer`: Default is true, if not false please add 128M to topology.mesos.executor.mem.mb
 
 ## Resource configuration
 

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -42,8 +42,8 @@ function clean {
 }
 
 function mvnPackage {
-  mvn -Dcheckstyle.skip=true package
-  mvn -Dcheckstyle.skip=true dependency:copy-dependencies
+  mvn package
+  mvn dependency:copy-dependencies
 }
 
 function prePackage {(

--- a/pom.xml
+++ b/pom.xml
@@ -155,5 +155,10 @@
         <artifactId>guava</artifactId>
         <version>18.0</version>
       </dependency>
+      <dependency>
+	<groupId>junit</groupId>
+	<artifactId>junit</artifactId>
+	<version>4.8.1</version>
+      </dependency>
     </dependencies>
   </project>

--- a/src/storm/mesos/MesosCommon.java
+++ b/src/storm/mesos/MesosCommon.java
@@ -30,6 +30,7 @@ public class MesosCommon {
   public static final String EXECUTOR_CPU_CONF = "topology.mesos.executor.cpu";
   public static final String EXECUTOR_MEM_CONF = "topology.mesos.executor.mem.mb";
   public static final String SUICIDE_CONF = "mesos.supervisor.suicide.inactive.timeout.secs";
+  public static final String AUTO_START_LOGVIEWER_CONF = "supervisor.autostart.logviewer";
 
   public static final double DEFAULT_CPU = 1;
   public static final double DEFAULT_MEM_MB = 1000;

--- a/src/storm/mesos/MesosSupervisor.java
+++ b/src/storm/mesos/MesosSupervisor.java
@@ -27,6 +27,11 @@ import org.apache.mesos.MesosExecutorDriver;
 import org.apache.mesos.Protos.*;
 import org.json.simple.JSONValue;
 
+import com.google.common.base.Optional;
+
+import storm.mesos.logviewer.ILogController;
+import storm.mesos.logviewer.LogViewerController;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
@@ -69,6 +74,13 @@ public class MesosSupervisor implements ISupervisor {
     LOG.info("Waiting for executor to initialize...");
     try {
       _executor.waitUntilRegistered();
+      
+      if (startLogViewer(conf)) {
+        LOG.info("Starting logviewer...");
+        ILogController logController = new LogViewerController();
+        logController.start();
+      }
+      
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }
@@ -182,6 +194,10 @@ public class MesosSupervisor implements ISupervisor {
 
   }
 
+  protected boolean startLogViewer(Map conf) {
+     return Optional.fromNullable((Boolean) conf.get(MesosCommon.AUTO_START_LOGVIEWER_CONF)).or(true);
+  }
+  
   public class SuicideDetector extends Thread {
     long _lastTime = System.currentTimeMillis();
     int _timeoutSecs;

--- a/src/storm/mesos/logviewer/ILogController.java
+++ b/src/storm/mesos/logviewer/ILogController.java
@@ -1,0 +1,11 @@
+package storm.mesos.logviewer;
+
+public interface ILogController {
+
+    public void start();
+    
+    public void stop();
+    
+    public boolean exists();
+    
+}

--- a/src/storm/mesos/logviewer/IUrlDetection.java
+++ b/src/storm/mesos/logviewer/IUrlDetection.java
@@ -1,0 +1,12 @@
+package storm.mesos.logviewer;
+
+import com.google.common.base.Optional;
+
+public interface IUrlDetection {
+
+    public boolean isReachable();
+    
+    public Optional<Integer> getPort();
+    
+    public void setPort(Optional<Integer> port);
+}

--- a/src/storm/mesos/logviewer/LogViewerController.java
+++ b/src/storm/mesos/logviewer/LogViewerController.java
@@ -1,0 +1,169 @@
+package storm.mesos.logviewer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ProcessBuilder.Redirect;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.yaml.snakeyaml.Yaml;
+
+import com.google.common.base.Optional;
+
+public class LogViewerController implements ILogController {
+    private static final Logger LOG = Logger.getLogger(LogViewerController.class);
+    protected Process process;
+    protected IUrlDetection urlDetector;
+    protected String installLocation;
+    protected Map<String, Object> config;
+    protected Optional<Integer> port;
+    protected static final String LOG_VIEWER_PORT = "logviewer.port";
+    
+    /**
+     * Create a log view controller with a SocketUrlDetector set to 
+     * the port that is in the storm.yaml config file. If no port is
+     * set then use the default of 8000. 
+     */
+    public LogViewerController() {
+        // Use a simplistic approach.
+        this(new SocketUrlDetection());
+    }
+    
+    /**
+     * Load a preconfigured Url detector to check for an existing logviewer.
+     * 
+     * @param urlDetector
+     */
+    public LogViewerController(IUrlDetection urlDetector) {
+        setUrlDetector(urlDetector);
+        initialize();
+    }
+    
+    /**
+     * Start up the logviewer, but before that is done a check is made to
+     * see if an existing logviewer (or process) is on the same port and report
+     * and error if so.
+     */
+    @Override
+    public void start() {
+       try {
+           if (!exists()){
+               launchLogViewer();
+           } else {
+               LOG.error("Failed to start logviewer because there is something on its port");
+           }    
+       } catch (Exception e) {
+           LOG.error("Failed to start logviewer", e);
+       }
+    }
+    
+    @Override
+    public void stop() {
+        getProcess().destroy();
+    }
+    
+    @Override
+    public boolean exists() {
+        return getUrlDetector().isReachable();
+    }
+    
+    public void setUrlDetector(IUrlDetection urlDetector) {
+        this.urlDetector = urlDetector;
+    }
+    
+    public IUrlDetection getUrlDetector() {
+        return urlDetector;
+    }
+    
+    public void setInstallLocation(String location) {
+        installLocation = location;
+    }
+    
+    public String getInstallLocation() {
+        return installLocation;
+    }
+
+    protected void setProcess(Process process) {
+        this.process = process;
+    }
+    
+    protected Process getProcess() {
+        return process;
+    }
+    
+    protected void setPort(Optional<Integer> oport) {
+        port = oport;
+    }
+    
+    protected Optional<Integer> getPort() {
+        return port;
+    }
+    
+    protected void setConfig(Map<String, Object> configuration) {
+        config = configuration;
+    }
+    
+    protected Map<String, Object> getConfig(){
+        return config;
+    }
+
+    protected void launchLogViewer () throws IOException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("launchLogViewer: home dir? " + getInstallLocation());
+        }
+        ProcessBuilder pb = createProcessBuilder(getInstallLocation());
+        setProcess(pb.start());       
+    }
+    
+    /**
+     * Create a process builder to launch the log viewer
+     * @param logDirectory
+     * @return
+     */
+    protected ProcessBuilder createProcessBuilder(String homeDirectory) {
+        ProcessBuilder pb = new ProcessBuilder(Paths.get(homeDirectory, "/bin/storm").toString(), "logviewer");
+         
+        // If anything goes wrong at startup we want to see it.
+        File log = Paths.get(homeDirectory, "/logs/logviewer-startup.log").toFile();
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(Redirect.appendTo(log)); 
+        return pb;
+    }
+    
+    @SuppressWarnings("unchecked")
+    protected void initialize() {
+        setInstallLocation(new File(".").getAbsolutePath());
+        
+        loadConfig();
+        
+        // If the storm configuration has defined a port use it.
+        if (getPort().isPresent()) {
+            getUrlDetector().setPort(getPort());
+        } else {
+            // Otherwise use the default 
+            LOG.info("No valid port in storm.yaml, using the on configured in the Url Detector " + 
+                getUrlDetector().getPort());
+            setPort(getUrlDetector().getPort());
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    protected void loadConfig() {
+        InputStream input = null;
+        try {
+            input = new FileInputStream(Paths.get(getInstallLocation(), "/conf/storm.yaml").toFile());
+            setConfig((Map<String, Object>) new Yaml().load(input));
+            LOG.info("Setting port for log viewer to " + config.get(LOG_VIEWER_PORT));
+            setPort(Optional.of((Integer) getConfig().get(LOG_VIEWER_PORT)));
+        } catch (Exception e) {
+            LOG.error("Failed to configure the log viewer controller,", e);
+            setPort(Optional.fromNullable(((Integer) null)));
+        } finally {
+            IOUtils.closeQuietly(input);
+        }
+    }
+}

--- a/src/storm/mesos/logviewer/SocketUrlDetection.java
+++ b/src/storm/mesos/logviewer/SocketUrlDetection.java
@@ -1,0 +1,59 @@
+package storm.mesos.logviewer;
+
+import java.net.InetAddress;
+import java.net.Socket;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+
+import com.google.common.base.Optional;
+
+public class SocketUrlDetection implements IUrlDetection {
+    public static final int DEFAULT_PORT = 8000;
+    protected Optional<Integer> port;
+    private static final Logger LOG = Logger.getLogger(SocketUrlDetection.class);
+    
+    public SocketUrlDetection() {
+        setPort(Optional.of(DEFAULT_PORT));
+    }
+    
+    public SocketUrlDetection(int port) {
+        setPort(Optional.of(port));
+    }
+    
+    public SocketUrlDetection(Optional<Integer> port) {
+        setPort(port);
+    }
+    
+    @Override
+    public boolean isReachable() {
+        Socket socket = null;
+        boolean reachable = false;
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Checking host " + InetAddress.getLocalHost() + " and port " + getPort());
+            }
+            
+            if (port.isPresent()) {
+                socket = new Socket(InetAddress.getLocalHost(), getPort().get());
+                reachable = true;
+            }
+        } catch (Exception e) {
+            // don't care.
+        } finally {
+            IOUtils.closeQuietly(socket);
+        }
+        return reachable;
+    }
+    
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public void setPort(Optional port) {
+        this.port = (Optional<Integer>) port;
+    }
+    
+    @Override
+    public Optional<Integer> getPort() {
+        return port;
+    }
+}

--- a/storm.yaml
+++ b/storm.yaml
@@ -7,6 +7,18 @@ storm.zookeeper.servers:
 nimbus.host: "localhost"
 # -----------------------------------------------------------
 
+
+### If this is not false then you need to add about 128m of mem usage to executor to account for the logviewer
+#supervisor.autostart.logviewer: false
+topology.mesos.executor.mem.mb: 1128  ## default is 1000
+
+# The default behavior is to launch the logvierwer unless autostart is false
+logviewer.port: 8000
+logviewer.childopts: "-Xmx128m"
+logviewer.cleanup.age.mins: 10080
+logviewer.appender.name: "A1"
+
+
 # You should not need to change anything below this line
 #--------------------------------------------------------
 


### PR DESCRIPTION
This launches a logviewer by default when a supervisor is launched by mesos. There is a new flag supervisor.autostart.logviewer which if set to false will prevent the logviewer from being launched. This was tested on a Vagrant 2 node cluster. This addresses issue [#6] (https://github.com/mesos/storm/issues/6)

I have the Vagrant setup/configuration if anyone would like PR created for that.  