### PR TITLE
Remove supervisor dead code

### DIFF
--- a/bin/storm-mesos
+++ b/bin/storm-mesos
@@ -10,10 +10,7 @@ def nimbus():
   os.chdir(STORM_PATH + "/..")
   os.system(STORM_CMD + " nimbus storm.mesos.MesosNimbus")
   
-def supervisor():
-  os.system(STORM_PATH + " supervisor storm.mesos.MesosSupervisor")
-
-COMMANDS = {"nimbus": nimbus, "supervisor": supervisor}
+COMMANDS = {"nimbus": nimbus}
 
 
 def main():


### PR DESCRIPTION
When running
```shell
storm-mesos supervisor
```
I get :
```shell
sh: /opt/storm/bin: is a directory
sh: /opt/storm/bin: is a directory
sh: /opt/storm/bin: is a directory
sh: /opt/storm/bin: is a directory
sh: /opt/storm/bin: is a directory
sh: /opt/storm/bin: is a directory
sh: /opt/storm/bin: is a directory
sh: /opt/storm/bin: is a directory
sh: /opt/storm/bin: is a directory
sh: /opt/storm/bin: is a directory

```
This pr fixes this.