### PR TITLE
Improving file server location and executor package handling

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -106,6 +106,7 @@ Storm/Mesos provides resource isolation between topologies. So you don't need to
 * `mesos.framework.checkpoint`: Enabled framework checkpoint or not. Defaults to false.
 * `mesos.offer.lru.cache.size`: LRU cache size. Defaults to "1000".
 * `mesos.local.file.server.port`: Port for the local file server to bind to. Defaults to a random port.
+* `mesos.local.file.server.location`: Location of conf folder with the storm.yaml in it. 
 * `mesos.framework.name`: Framework name. Defaults to "Storm!!!".
 * `mesos.framework.principal`: Framework principal to use to register with Mesos
 * `mesos.framework.secret.file`:  Location of file that contains the principal's secret. Secret cannot end with a NL.


### PR DESCRIPTION
This PR fixes two issues.

1. When the local file server is started locally to mainly serve `storm.yaml` to storm workers, the code assumes the conf directory to be `conf`. But this can fail especially when storm-mesos process is started through upstart scripts etc. Hence, we need to provide a way to explicitly pass this location to help in these cases. This fix allows the conf location to be passed using `mesos.local.file.server.location`. If not provided, it will fallback to `conf`

2. When we rely on mesos to download the storm-mesos package (when the workers are scheduled) it might contain additional characters at the end. For example, if we are downloading from hdfs the URI will have `?op=OPEN` at the end. This can fail the complete command that gets executed after that. Hence, instead of relying on mesos to do the download for us, we are explicitly using wget to do that and use that also to rename the file.