### PR TITLE
propagate exit code from the subprocess launched by the storm-mesos wrapper script

### DIFF
--- a/bin/storm-mesos
+++ b/bin/storm-mesos
@@ -11,7 +11,7 @@ STORM_CMD = STORM_PATH + "/storm"
 def nimbus(*args):
     os.chdir(STORM_PATH + "/..")
     args = [STORM_CMD, "nimbus", "storm.mesos.MesosNimbus"] + list(args)
-    subprocess.call(args)
+    sys.exit(subprocess.call(args))
 
 COMMANDS = {"nimbus": nimbus}
 


### PR DESCRIPTION
This solves issue #17 

I tested before-and-after following these steps:

1. Built the storm-mesos package: `bin/build-release.sh`
2. Went to the build dir:  `cd _release/storm-mesos-0.9.6`
3. Ran the wrapper script:  `bin/storm-mesos nimbus`
4. Observed that it failed (as expected on my laptop without running in a vagrant / docker set up), but that the exit code from the script was 0: `echo $?`
5. Made the change in this PR.
6. Rebuilt the package: `cd ../.. ; bin/build-release.sh ; cd _release/storm-mesos-0.9.6`
7. Ran wrapper again, and observed that the exit code was 13 as I expected: `echo $?`