### PR TITLE
allow simultaneous launching of 2+ worker processes per host

### DIFF
--- a/src/main/storm/mesos/MesosNimbus.java
+++ b/src/main/storm/mesos/MesosNimbus.java
@@ -789,15 +789,11 @@ public class MesosNimbus implements INimbus {
         executorInfoBuilder
             .setName(executorName)
             .setExecutorId(ExecutorID.newBuilder().setValue(details.getId()))
-            .setData(ByteString.copyFromUtf8(executorDataStr));
-        if (!subtractedExecutorResources) {
-          subtractedExecutorResources = true;
-          executorInfoBuilder
-              .addAllResources(executorCpuResources)
-              .addAllResources(executorMemResources);
-          if (executorPortsResources != null) {
-            executorInfoBuilder.addAllResources(executorPortsResources);
-          }
+            .setData(ByteString.copyFromUtf8(executorDataStr))
+            .addAllResources(executorCpuResources)
+            .addAllResources(executorMemResources);
+        if (executorPortsResources != null) {
+          executorInfoBuilder.addAllResources(executorPortsResources);
         }
         if (_container.isPresent()) {
           // An ugly workaround for a bug in DCOS


### PR DESCRIPTION
One of the logic changes in PR #65 broke the ability to simultaneously launch
more than 1 worker process for a given topology.  The cause of the breakage
was intentionally avoiding inclusion of the executor's resources into the
ExecutorInfo structure associated with the mesos tasks (storm workers).
This is problematic because the mesos-master rejects tasks whose ExecutorInfo
isn't identical to other tasks under the same executor.  Notably, since the
executor is already running for subsequent tasks, the resources that are
added to these subsequent tasks' ExecutorInfo aren't actually used, so there
is no advantage in attempting to avoid their inclusion.

FFR, this is the commit with that change:
* af8c49beac04b530c33c1401c829caaa8e368a35

After this fix I was able to instantly launch 3 workers for a topology
on the same mesos-slave host.