### PR TITLE
Fix another regression: a crash introduced in commit feb892f

### DIFF
--- a/src/main/storm/mesos/MesosNimbus.java
+++ b/src/main/storm/mesos/MesosNimbus.java
@@ -306,7 +306,7 @@ public class MesosNimbus implements INimbus {
 
     for (Resource r : offer.getResourcesList()) {
       if (r.hasReservation()) {
-        // skip resources with reservations
+        // skip resources with dynamic reservations
         continue;
       }
       if (r.getType() == Type.SCALAR) {
@@ -495,7 +495,7 @@ public class MesosNimbus implements INimbus {
     double valueNeeded = value;
     for (Resource r : offerResources) {
       if (r.hasReservation()) {
-        // skip resources with reservations
+        // skip resources with dynamic reservations
         continue;
       }
       if (r.getType() == Type.SCALAR &&
@@ -739,13 +739,11 @@ public class MesosNimbus implements INimbus {
           Collections.sort(offerResources, new ResourceRoleComparator());
         }
 
-        List<Resource> executorCpuResources = null;
-        List<Resource> executorMemResources = null;
+        List<Resource> executorCpuResources = getResourcesScalar(offerResources, executorCpu, "cpus");
+        List<Resource> executorMemResources = getResourcesScalar(offerResources, executorMem, "mem");
         List<Resource> executorPortsResources = null;
         if (!subtractedExecutorResources) {
-          executorCpuResources = getResourcesScalar(offerResources, executorCpu, "cpus");
           offerResources = subtractResourcesScalar(offerResources, executorCpu, "cpus");
-          executorMemResources = getResourcesScalar(offerResources, executorMem, "mem");
           offerResources = subtractResourcesScalar(offerResources, executorMem, "mem");
           subtractedExecutorResources = true;
         }


### PR DESCRIPTION
Commit feb892f (from PR #79) introduced a NullPointerException crash:

After the first pass through the `computeResourcesForSlot()` main loop, the
`executorCpuResources` and `executorMemResources` variables are not populated,
and thus incorreclty null, because `subtractedExecutorResources ` was set to
true on the 1st pass.

The fix is to unconditionally set them to the requested resource amounts
unconditionally, and only subtract the resources out of the offer on the
1st pass.

Also an unrelated change:  clarify that the reservations that are being skipped
in a couple functions are *dynamic* reservations.