### PR TITLE
Shade all possible dependencies except mesos. 

### DIFF
--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -69,6 +69,10 @@ function package {(
   _rm $stormDir/*.jar
 
   # copies storm-mesos jar over
+  # We only want the shaded jar. Its important to remove the original
+  # jar so we dont have both shaded as well as original jar in the classpath
+  # for mesos nimbus
+  rm target/original-storm-0.9.6.jar
   cp target/*.jar $stormDir/lib/
   cp bin/storm-mesos $stormDir/bin/
   cp bin/run-with-marathon.sh $stormDir/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,50 @@
                 <exclude>defaults.yaml</exclude>
               </excludes>
             </filter>
-          </filters>
+	  </filters>
+	  <!-- The mesos/storm dependencies can conflict with the topology jar's dependencies.
+               To avoid this problem, we shade every dependency of mesos/storm that we can.  We weren't
+	       able to shade org.apache.mesos because it is loaded directly by the Mesos "drivers",
+               that run within the MesosNimbus and MesosSupervisor processes.
+         -->
+          <relocations>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>com.google.common.shaded</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.protobuf</pattern>
+              <shadedPattern>com.google.protobuf.shaded</shadedPattern>
+            </relocation>
+	    <relocation>
+              <pattern>org.apache.commons</pattern>
+              <shadedPattern>com.apache.commons.shaded</shadedPattern>
+            </relocation>
+            <relocation>
+	      <pattern>org.slf4j</pattern>
+              <shadedPattern>org.slf4j.shaded</shadedPattern>
+            </relocation>
+            <relocation>
+	      <pattern>org.apache.log4j</pattern>
+              <shadedPattern>org.apache.log4j.shaded</shadedPattern>
+            </relocation>
+            <relocation>
+	      <pattern>org.json.simple</pattern>
+              <shadedPattern>org.json.simple.shaded</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.guava</pattern>
+              <shadedPattern>com.google.guava.shaded</shadedPattern>
+            </relocation>
+	    <relocation>
+              <pattern>org.mortbay</pattern>
+              <shadedPattern>org.mortbay.shaded</shadedPattern>
+	    </relocation>
+	    <relocation>
+	      <pattern>javax.servlet</pattern>
+              <shadedPattern>javax.servlet.shaded</shadedPattern>
+	    </relocation>
+          </relocations>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
The dependencies in the mesos/storm could potentially conflict with those in the topologies. For instance, mesos/storm codebase depends on guava-18. If the topology submitted by the users of the mesos/storm cluster depend on a version of guava that is not compatible with guava-18, it would result in a conflict. So its good practice to shade all the dependencies of mesos/storm.
 
We aren't able to shade org.apache.mesos because it is loaded directly by the Mesos
"drivers", that run within the MesosNimbus and MesosSupervisor processes.

@erikdw @JessicaLHartog @brndnmtthws @tnachen @JessicaLHartog