### PR TITLE
Changes to get docker working on vagrant.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD . /work
 WORKDIR /work
 
 RUN apt-get update && \
-  apt-get install -yq openjdk-7-jdk maven wget && \
+  apt-get install -y openjdk-7-jdk maven wget && \
   ./bin/build-release.sh main && \
   mkdir -p /opt/storm && \
   tar xf storm-mesos-*.tgz -C /opt/storm --strip=1 && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,12 @@ VAGRANTFILE_API_VERSION = "2"
 
 $provision_script = <<SCRIPT
 
+function install_package {
+  name_of_package=$1
+  echo "Installing ${name_of_package}"
+  apt-get -o Acquire::http::Timeout=1 -o Acquire::ftp::Timeout=1 -y install ${name_of_package}
+}
+
 PREFIX="PROVISIONER:"
 
 set -e
@@ -20,16 +26,22 @@ DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
 CODENAME=$(lsb_release -cs)
 echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" | sudo tee /etc/apt/sources.list.d/mesosphere.list
 
-apt-get -q -y update
+apt-get -o Acquire::http::Timeout=1 -o Acquire::ftp::Timeout=1 -y update
 echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
-apt-get -q -y install oracle-java8-installer
-apt-get -q -y install oracle-java8-set-default
-apt-get -q -y install libcurl3
-apt-get -q -y install zookeeperd
-apt-get -q -y install aria2
+
+echo "Installing oracle-java8-installer..."
+install_package "oracle-java8-installer"
+echo "Installing oracle-java8-set-default..."
+apt-get -o Acquire::http::Timeout=1 -o Acquire::ftp::Timeout=1 -y install oracle-java8-set-default
+echo "Installing libcurl3..."
+apt-get -o Acquire::http::Timeout=1 -o Acquire::ftp::Timeout=1 -y install libcurl3
+echo "Installing zookeeperd..."
+apt-get -o Acquire::http::Timeout=1 -o Acquire::ftp::Timeout=1 -y install zookeeperd
+echo "Installing aria2..."
+apt-get -o Acquire::http::Timeout=1 -o Acquire::ftp::Timeout=1 -y install aria2
 
 echo "${PREFIX}Installing mesos ..."
-apt-get -q -y install mesos
+apt-get -o Acquire::http::Timeout=1 -o Acquire::ftp::Timeout=1 -y install mesos=0.25.0-0.2.70.ubuntu1404
 echo "Done"
 
 ln -sf /usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/libjvm.so /usr/lib/libjvm.so
@@ -37,7 +49,7 @@ ln -sf /usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/libjvm.so /usr/lib/libjvm
 echo "${PREFIX}Successfully provisioned machine for storm development"
 
 # Install docker
-apt-get -q -y install docker.io
+apt-get -o Acquire::http::Timeout=1 -o Acquire::ftp::Timeout=1 -y install docker.io
 
 SCRIPT
 

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -98,7 +98,9 @@ function package {(
 )}
 
 function dockerImage {(
-  docker build -t mesos/storm:git-`git rev-parse --short HEAD`
+  cmd="docker build -t karthick/mesos-storm:git-`git rev-parse --short HEAD` ."
+  echo $cmd
+  $cmd
 )}
 
 # Ensure we have GNU tar so that we can use options such as --owner, etc.

--- a/storm.yaml
+++ b/storm.yaml
@@ -1,4 +1,4 @@
-# Please change these for your cluster 
+# Please change these for your cluster
 # to reflect your cluster settings
 # -----------------------------------------------------------
 mesos.master.url: "zk://localhost:2181/mesos"
@@ -9,14 +9,14 @@ storm.zookeeper.servers:
 
 # Worker resources
 topology.mesos.worker.cpu: 1.0
-# Worker heap with 20% overhead
-topology.mesos.worker.mem.mb: 1200
-worker.childopts: "-Xmx1000m"
+# Worker heap with 25% overhead
+topology.mesos.worker.mem.mb: 512
+worker.childopts: "-Xmx384m"
 
 # Supervisor resources
 topology.mesos.executor.cpu: 0.1
 topology.mesos.executor.mem.mb: 500 # Supervisor memory, with 20% overhead
-supervisor.childopts: "-Xmx256m"
+supervisor.childopts: "-Xmx400m"
 
 # The default behavior is to launch the logviewer unless autostart is false.
 # If you enable the logviewer, you'll need to add memory overhead to the
@@ -30,11 +30,11 @@ supervisor.autostart.logviewer: true
 # Use the public Mesosphere Storm build
 # Please note that it won't work with other distributions.
 # You may want to make this empty if you use `mesos.container.docker.image` instead.
-# mesos.executor.uri: "http://downloads.mesosphere.io/storm/storm-mesos-0.9.0.1.tgz"
+# mesos.executor.uri: "file:///usr/local/storm/storm-mesos-0.9.6.tgz"
 
 # Alternatively, use a Docker image instead of URI. If an image is specified,
 # Docker will be used instead of Mesos containers.
-mesos.container.docker.image: mesosphere/storm
+mesos.container.docker.image: "mesosphere/storm"
 
 # Use Netty to avoid ZMQ dependencies
 storm.messaging.transport: "backtype.storm.messaging.netty.Context"

--- a/vagrant/start-nimbus.sh
+++ b/vagrant/start-nimbus.sh
@@ -18,7 +18,7 @@ kill `ps aux | grep backtype.storm.ui.cor[e] | awk '{print $2}'` &> /dev/null ||
 # Start storm nimbus, which also acts as the mesos scheduler in this case.
 # Point the STORM_CONF_DIR to where the repo's storm.yaml lives, so we can modify it
 # without having to rebuild the framework tarball and fully reprovision.
-STORM_CONF_DIR=/vagrant bin/storm-mesos nimbus &
+MESOS_NATIVE_JAVA_LIBRARY=/usr/lib/libmesos.so STORM_CONF_DIR=/vagrant bin/storm-mesos nimbus &
 
 # Start storm UI
 bin/storm ui &


### PR DESCRIPTION
Detailed list of changes:
  - Get rid of -q parameter in apt-get. No harm printing extra info -
   infact, we want to know more detailed information about errors, if
   any.
 - Set a lower timeout value for apt-get. This helps avoid long pause
   times when "apt-get update" is run thereby improving the time that it
   takes to bring up the vagrant machine.
 - Fix the broken "bin/build-release.sh dockerImage" functionality
 - Tune the memory settings for supervisor and worker process in order
   to avoid container from exiting due to OOM
 - Set MESOS_NATIVE_JAVA_LIBRARY environment variable while launching
   nimbus inorder to avoid container failing like below
~~~
     # vagrant@master:~$ sudo docker logs 84ad44355638
     #  SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
     #  SLF4J: Defaulting to no-operation (NOP) logger implementation
     #  SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder
     #  for further details.
     #  Failed to load native Mesos library from null
~~~