### PR TITLE
Fix NoClassDefFoundError with shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,11 @@
       <version>3.4</version>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.5</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.4</version>


### PR DESCRIPTION
This fixes a `NoClassDefFoundError` caused by the shading that we do.

`MesosNimbus` explicitly uses the non-lang3 version of `StringUtils` from `commons-lang`, but it wasn't being included in the shaded jar, but the namespace filter `org.apache.commons` was picking it out regardless.