### PR TITLE
create unique task ID per task launch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
 
+ARG MESOS_RELEASE=0.25.0
+ARG STORM_RELEASE=0.9.6
+ARG MIRROR=http://www.gtlib.gatech.edu/pub
+
 ADD . /work
 
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Dockerfile for Storm Mesos framework
 #
-FROM mesosphere/mesos:0.25.0-0.2.70.ubuntu1404
+FROM mesosphere/mesos:0.27.0-0.2.190.ubuntu1404
 MAINTAINER Timothy Chen <tnachen@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -11,7 +11,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
 
-ARG MESOS_RELEASE=0.25.0
+ARG MESOS_RELEASE=0.27.0
 ARG STORM_RELEASE=0.9.6
 ARG MIRROR=http://www.gtlib.gatech.edu/pub
 

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -109,7 +109,11 @@ function package {(
 )}
 
 function dockerImage {(
-  cmd="docker build -t mesos/storm:git-`git rev-parse --short HEAD` ."
+  cmd="docker build \
+       --build-arg MESOS_RELEASE=$MESOS_RELEASE \
+       --build-arg STORM_RELEASE=$STORM_RELEASE \
+       --build-arg MIRROR=$MIRROR \
+        -t mesos/storm:git-`git rev-parse --short HEAD` ."
   echo $cmd
   $cmd
 )}

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,18 @@
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>1.6.6</version>
+        <exclusions>
+        <!-- slf4j-api is provided by storm-core. We might as well
+               use the one that is provided to us by storm rather than including
+               the slf4j-api classes in the jar.
+               WARNING: Please do *not* shade org.slf4j. Classes from org.slf4j
+                        are referenced within log4j-over-slf4j and shading them
+                        would lead to java.lang.NoClassDefFoundError -->
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.mortbay.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <storm.default.version>0.9.6</storm.default.version>
-    <mesos.default.version>0.24.1</mesos.default.version>
-    <mesos.version>0.24.1</mesos.version>
+    <mesos.default.version>0.27.0</mesos.default.version>
+    <mesos.version>0.27.0</mesos.version>
   </properties>
 
   <profiles>

--- a/storm-shim-9x/src/main/java/storm/mesos/shims/LocalStateShim.java
+++ b/storm-shim-9x/src/main/java/storm/mesos/shims/LocalStateShim.java
@@ -18,7 +18,8 @@
 package storm.mesos.shims;
 
 import backtype.storm.utils.LocalState;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -26,7 +27,7 @@ import java.util.Map;
 
 public class LocalStateShim implements ILocalStateShim {
   LocalState _state;
-  private static final Logger LOG = Logger.getLogger(LocalStateShim.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LocalStateShim.class);
 
   public LocalStateShim(String localDir) throws IOException {
     _state = new LocalState(localDir);

--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -70,6 +70,19 @@
             </filter>
           </filters>
           <relocations>
+          <!-- List of dependencies that should not be shaded
+                 1. org.slf4j:
+                     shading org.slf4j would lead to a couple of issues:
+                     a) Shading org.slf4j corresponding to slf4j-api would prevent its classes
+                        from binding to the concrete implementations that the storm's
+                        logging libraries provide. Eg. org.slf4j.Logger interface in slf4j-api
+                        becomes org.slf4j.shaded.Logger and none of the Logger implementations
+                        provided by storm would implement org.slf4j.shaded.Logger. This in turn
+                        would lead slf4j-api to bind to NOPLogger resulting in loss of application
+                        logs.
+                     b) Classes from org.slf4j are referenced within slf4j bridge artifacts like
+                        'log4j-over-slf4j'. So shading them would cause MesosNimbus to throw
+                        java.lang.NoClassDefFoundError -->
             <relocation>
               <pattern>com.google.common</pattern>
               <shadedPattern>com.google.common.shaded</shadedPattern>
@@ -81,10 +94,6 @@
             <relocation>
               <pattern>org.apache.commons</pattern>
               <shadedPattern>com.apache.commons.shaded</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>org.slf4j</pattern>
-              <shadedPattern>org.slf4j.shaded</shadedPattern>
             </relocation>
             <relocation>
               <pattern>org.apache.log4j</pattern>

--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -166,7 +166,8 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.18</version>
     </dependency>
     <dependency>
       <groupId>org.mortbay.jetty</groupId>

--- a/storm/src/main/storm/mesos/LocalFileServer.java
+++ b/storm/src/main/storm/mesos/LocalFileServer.java
@@ -18,7 +18,6 @@
 package storm.mesos;
 
 import com.google.common.base.Optional;
-import org.apache.log4j.Logger;
 import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Handler;
 import org.mortbay.jetty.Server;
@@ -26,6 +25,8 @@ import org.mortbay.jetty.handler.ContextHandler;
 import org.mortbay.jetty.handler.HandlerList;
 import org.mortbay.jetty.handler.ResourceHandler;
 import org.mortbay.jetty.nio.SelectChannelConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.URI;
@@ -37,7 +38,7 @@ import java.net.URI;
 
 public class LocalFileServer {
 
-  public static final Logger LOG = Logger.getLogger(LocalFileServer.class);
+  public static final Logger LOG = LoggerFactory.getLogger(LocalFileServer.class);
   private Server _server = new Server();
 
   public static void main(String[] args) throws Exception {
@@ -59,7 +60,7 @@ public class LocalFileServer {
   public URI serveDir(String uriPath, String filePath, Optional<Integer> port) throws Exception {
 
     if (port.isPresent()) {
-      LOG.info("Starting local file server on port: " + port.get());
+      LOG.info("Starting local file server on port: {}", port.get());
       _server = new Server(port.get());
     } else {
       _server = new Server();

--- a/storm/src/main/storm/mesos/MesosCommon.java
+++ b/storm/src/main/storm/mesos/MesosCommon.java
@@ -19,12 +19,14 @@ package storm.mesos;
 
 import backtype.storm.scheduler.TopologyDetails;
 import com.google.common.base.Optional;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MesosCommon {
-  public static final Logger LOG = Logger.getLogger(MesosCommon.class);
+  public static final Logger LOG = LoggerFactory.getLogger(MesosCommon.class);
 
   public static final String WORKER_CPU_CONF = "topology.mesos.worker.cpu";
   public static final String WORKER_MEM_CONF = "topology.mesos.worker.mem.mb";
@@ -51,7 +53,7 @@ public class MesosCommon {
   public static String hostFromAssignmentId(String assignmentId, String delimiter) {
     final int last = assignmentId.lastIndexOf(delimiter);
     String host = assignmentId.substring(last + delimiter.length());
-    LOG.debug("assignmentId=" + assignmentId + " host=" + host);
+    LOG.debug("assignmentId={} host={}", assignmentId, host);
     return host;
   }
 

--- a/storm/src/main/storm/mesos/MesosCommon.java
+++ b/storm/src/main/storm/mesos/MesosCommon.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class MesosCommon {
   public static final Logger LOG = LoggerFactory.getLogger(MesosCommon.class);
@@ -76,9 +77,9 @@ public class MesosCommon {
 
   public static String timestampMillis() {
     long now = System.currentTimeMillis();
-    long sec = now / 1000L;
-    long msec = now % 1000L;
-    return String.valueOf(sec) + "." + String.valueOf(msec);
+    long secs = TimeUnit.MILLISECONDS.toSeconds(now);
+    long msecs = now - TimeUnit.SECONDS.toMillis(secs);
+    return String.format("%d.%03d", secs, msecs);
   }
 
   public static String taskId(String nodeid, int port) {

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -18,39 +18,72 @@
 package storm.mesos;
 
 import backtype.storm.Config;
-import backtype.storm.scheduler.*;
+import backtype.storm.scheduler.INimbus;
+import backtype.storm.scheduler.IScheduler;
+import backtype.storm.scheduler.SupervisorDetails;
+import backtype.storm.scheduler.Topologies;
+import backtype.storm.scheduler.TopologyDetails;
+import backtype.storm.scheduler.WorkerSlot;
 import com.google.common.base.Optional;
 import com.google.protobuf.ByteString;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
 import org.apache.mesos.MesosSchedulerDriver;
 import org.apache.mesos.Protos;
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.CommandInfo;
 import org.apache.mesos.Protos.CommandInfo.URI;
+import org.apache.mesos.Protos.ContainerInfo;
+import org.apache.mesos.Protos.Credential;
+import org.apache.mesos.Protos.ExecutorID;
+import org.apache.mesos.Protos.ExecutorInfo;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.FrameworkInfo;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.Value.Range;
 import org.apache.mesos.Protos.Value.Ranges;
 import org.apache.mesos.Protos.Value.Scalar;
 import org.apache.mesos.Protos.Value.Type;
 import org.apache.mesos.SchedulerDriver;
 import org.json.simple.JSONValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 import storm.mesos.shims.CommandLineShimFactory;
 import storm.mesos.shims.ICommandLineShim;
 import storm.mesos.shims.LocalStateShim;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static storm.mesos.PrettyProtobuf.*;
+import static storm.mesos.PrettyProtobuf.offerMapToString;
+import static storm.mesos.PrettyProtobuf.offerToString;
 
 public class MesosNimbus implements INimbus {
   public static final String CONF_EXECUTOR_URI = "mesos.executor.uri";
@@ -71,7 +104,7 @@ public class MesosNimbus implements INimbus {
   public static final String CONF_MESOS_PREFER_RESERVED_RESOURCES = "mesos.prefer.reserved.resources";
   public static final String CONF_MESOS_CONTAINER_DOCKER_IMAGE = "mesos.container.docker.image";
   public static final String FRAMEWORK_ID = "FRAMEWORK_ID";
-  private static final Logger LOG = Logger.getLogger(MesosNimbus.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MesosNimbus.class);
   private final Object _offersLock = new Object();
   protected java.net.URI _configUrl;
   LocalStateShim _state;
@@ -232,21 +265,22 @@ public class MesosNimbus implements INimbus {
       if (_offers == null) {
         return;
       }
-      LOG.debug("resourceOffers: Currently have " + _offers.size() + " offers buffered" +
-          (_offers.size() > 0 ? (":" + offerMapToString(_offers)) : ""));
+      LOG.debug("resourceOffers: Currently have {} offers buffered {}",
+                _offers.size(), (_offers.size() > 0 ? (":" + offerMapToString(_offers)) : ""));
+
       for (Protos.Offer offer : offers) {
         if (isHostAccepted(offer.getHostname())) {
-          LOG.debug("resourceOffers: Recording offer from host: " +
-              offer.getHostname() + ", offerId: " + offer.getId().getValue());
+          LOG.debug("resourceOffers: Recording offer from host: {}, offerId: {}",
+                    offer.getHostname(), offer.getId().getValue());
           _offers.put(offer.getId(), offer);
         } else {
-          LOG.debug("resourceOffers: Declining offer from host: " +
-              offer.getHostname() + ", offerId: " + offer.getId().getValue());
+          LOG.debug("resourceOffers: Declining offer from host: {}, offerId: {}",
+                    offer.getHostname(), offer.getId().getValue());
           driver.declineOffer(offer.getId());
         }
       }
-      LOG.debug("resourceOffers: After processing offers, now have " +
-          _offers.size() + " offers buffered:" + offerMapToString(_offers));
+      LOG.debug("resourceOffers: After processing offers, now have {} offers buffered: {}",
+                _offers.size(), offerMapToString(_offers));
     }
   }
 
@@ -267,7 +301,7 @@ public class MesosNimbus implements INimbus {
 
   protected void createLocalServerPort() {
     Integer port = (Integer) _conf.get(CONF_MESOS_LOCAL_FILE_SERVER_PORT);
-    LOG.debug("LocalFileServer configured to listen on port: " + port);
+    LOG.debug("LocalFileServer configured to listen on port: {}", port);
     _localFileServerPort = Optional.fromNullable(port);
   }
 
@@ -275,7 +309,7 @@ public class MesosNimbus implements INimbus {
     _httpServer = new LocalFileServer();
     _configUrl = _httpServer.serveDir("/generated-conf", _generatedConfPath.toString(), _localFileServerPort);
 
-    LOG.info("Started HTTP server from which config for the MesosSupervisor's may be fetched. URL: " + _configUrl);
+    LOG.info("Started HTTP server from which config for the MesosSupervisor's may be fetched. URL: {}", _configUrl);
   }
 
   protected MesosSchedulerDriver createMesosDriver() throws IOException {
@@ -330,7 +364,7 @@ public class MesosNimbus implements INimbus {
     resources.ports.addAll(portList);
 
     LOG.debug("Offer: " + offerToString(offer));
-    LOG.debug("Extracted resources: " + resources.toString());
+    LOG.debug("Extracted resources: {}", resources.toString());
     return resources;
   }
 
@@ -414,10 +448,10 @@ public class MesosNimbus implements INimbus {
   public Collection<WorkerSlot> allSlotsAvailableForScheduling(
       Collection<SupervisorDetails> existingSupervisors, Topologies topologies, Set<String> topologiesMissingAssignments) {
     synchronized (_offersLock) {
-      LOG.debug("allSlotsAvailableForScheduling: Currently have " + _offers.size() + " offers buffered" +
-          (_offers.size() > 0 ? (":" + offerMapToString(_offers)) : ""));
+      LOG.debug("allSlotsAvailableForScheduling: Currently have {} offers buffered {}",
+                _offers.size(), (_offers.size() > 0 ? (":" + offerMapToString(_offers)) : ""));
       if (!topologiesMissingAssignments.isEmpty()) {
-        LOG.info("Topologies that need assignments: " + topologiesMissingAssignments.toString());
+        LOG.info("Topologies that need assignments: {}", topologiesMissingAssignments.toString());
 
         // Revive any filtered offers
         _driver.reviveOffers();
@@ -444,8 +478,8 @@ public class MesosNimbus implements INimbus {
       }
     }
 
-    LOG.info("allSlotsAvailableForScheduling: pending topologies' max resource requirements per worker: cpu: " +
-        String.valueOf(cpu) + " & mem: " + String.valueOf(mem));
+    LOG.info("allSlotsAvailableForScheduling: pending topologies' max resource requirements per worker: cpu: {} & mem: {}",
+             String.valueOf(cpu), String.valueOf(mem));
 
     List<WorkerSlot> allSlots = new ArrayList<>();
 
@@ -456,9 +490,9 @@ public class MesosNimbus implements INimbus {
           List<WorkerSlot> offerSlots = toSlots(offer, cpu, mem, supervisorExists);
           if (offerSlots.isEmpty()) {
             _offers.clearKey(offer.getId());
-            LOG.debug("Declining offer `" + offerToString(offer) + "' because it wasn't " +
-                "usable to create a slot which fits largest pending topologies' aggregate needs " +
-                "(max cpu: " + String.valueOf(cpu) + " max mem: " + String.valueOf(mem) + ")");
+            LOG.debug("Declining offer `{}' because it wasn't usable to create a slot which fits largest " +
+                      "pending topologies' aggregate needs (max cpu: {} max mem: {})",
+                      offerToString(offer), String.valueOf(cpu), String.valueOf(mem));
           } else {
             allSlots.addAll(offerSlots);
           }
@@ -466,10 +500,10 @@ public class MesosNimbus implements INimbus {
       }
     }
 
-    LOG.info("Number of available slots: " + allSlots.size());
+    LOG.info("Number of available slots: {}", allSlots.size());
     if (LOG.isDebugEnabled()) {
       for (WorkerSlot slot : allSlots) {
-        LOG.debug("available slot: " + slot);
+        LOG.debug("available slot: {}", slot);
       }
     }
     return allSlots;
@@ -637,9 +671,8 @@ public class MesosNimbus implements INimbus {
       String topologyId = topologyToSlots.getKey();
       for (WorkerSlot slot : topologyToSlots.getValue()) {
         TopologyDetails details = topologies.getById(topologyId);
-        LOG.debug("assignSlots: topologyId: " + topologyId + " worker being assigned to slot: " + slot +
-            " with workerCpu: " + MesosCommon.topologyWorkerCpu(_conf, details) +
-            " workerMem: " + MesosCommon.topologyWorkerMem(_conf, details));
+        LOG.debug("assignSlots: topologyId: {} worker being assigned to slot: {} with workerCpu: {} workerMem: {}",
+                  topologyId, slot, MesosCommon.topologyWorkerCpu(_conf, details), MesosCommon.topologyWorkerMem(_conf, details));
       }
     }
     synchronized (_offersLock) {
@@ -668,7 +701,7 @@ public class MesosNimbus implements INimbus {
       List<LaunchTask> tasks = toLaunch.get(id);
       List<TaskInfo> launchList = new ArrayList<>();
 
-      LOG.info("Launching tasks for offerId: " + id.getValue() + ":" + launchTaskListToString(tasks));
+      LOG.info("Launching tasks for offerId: {} : {}", id.getValue(), launchTaskListToString(tasks));
       for (LaunchTask t : tasks) {
         launchList.add(t.getTask());
         _usedOffers.put(t.getTask().getTaskId(), t.getOffer());
@@ -819,8 +852,7 @@ public class MesosNimbus implements INimbus {
                   .setValue(commandLineShim.getCommandLine()));
         }
 
-        LOG.info("Launching task with Mesos Executor data: <"
-            + executorDataStr + ">");
+        LOG.info("Launching task with Mesos Executor data: < {} >", executorDataStr);
         TaskInfo task = TaskInfo.newBuilder()
             .setName(taskName)
             .setTaskId(taskId)
@@ -834,7 +866,7 @@ public class MesosNimbus implements INimbus {
         Offer newOffer = offer.toBuilder()
             .addAllResources(task.getResourcesList()).build();
 
-        LOG.debug("Launching task: " + task.toString());
+        LOG.debug("Launching task: {}", task.toString());
 
         toLaunch.get(id).add(new LaunchTask(task, newOffer));
       }

--- a/storm/src/main/storm/mesos/MesosSupervisor.java
+++ b/storm/src/main/storm/mesos/MesosSupervisor.java
@@ -18,17 +18,22 @@
 package storm.mesos;
 
 
-
-import backtype.storm.generated.JavaObject;
-import backtype.storm.generated.JavaObjectArg;
 import backtype.storm.scheduler.ISupervisor;
 import backtype.storm.utils.Utils;
-import org.apache.log4j.Logger;
+import clojure.lang.PersistentVector;
 import org.apache.mesos.Executor;
 import org.apache.mesos.ExecutorDriver;
 import org.apache.mesos.MesosExecutorDriver;
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.ExecutorInfo;
+import org.apache.mesos.Protos.FrameworkInfo;
+import org.apache.mesos.Protos.SlaveInfo;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.TaskState;
+import org.apache.mesos.Protos.TaskStatus;
 import org.json.simple.JSONValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import storm.mesos.logviewer.LogViewerController;
 import storm.mesos.shims.ILocalStateShim;
 import storm.mesos.shims.LocalStateShim;
@@ -39,12 +44,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
-import clojure.lang.PersistentVector;
 
 public class MesosSupervisor implements ISupervisor {
-  public static final Logger LOG = Logger.getLogger(MesosSupervisor.class);
+  public static final Logger LOG = LoggerFactory.getLogger(MesosSupervisor.class);
 
   volatile String _id = null;
   volatile String _assignmentId = null;
@@ -143,11 +146,11 @@ public class MesosSupervisor implements ISupervisor {
 
     @Override
     public void registered(ExecutorDriver driver, ExecutorInfo executorInfo, FrameworkInfo frameworkInfo, SlaveInfo slaveInfo) {
-      LOG.info("Received executor data <" + executorInfo.getData().toStringUtf8() + ">");
+      LOG.info("Received executor data <{}>", executorInfo.getData().toStringUtf8());
       Map ids = (Map) JSONValue.parse(executorInfo.getData().toStringUtf8());
       _id = (String) ids.get(MesosCommon.SUPERVISOR_ID);
       _assignmentId = (String) ids.get(MesosCommon.ASSIGNMENT_ID);
-      LOG.info("Registered supervisor with Mesos: " + _id + ", " + _assignmentId);
+      LOG.info("Registered supervisor with Mesos: {}, {} ", _id, _assignmentId);
 
       // Completed registration, let anything waiting for us to do so continue
       _registeredLatch.countDown();
@@ -157,7 +160,7 @@ public class MesosSupervisor implements ISupervisor {
     @Override
     public void launchTask(ExecutorDriver driver, TaskInfo task) {
       int port = MesosCommon.portFromTaskId(task.getTaskId().getValue());
-      LOG.info("Received task assignment for port " + port);
+      LOG.info("Received task assignment for port {}", port);
       _state.put(Integer.toString(port), Boolean.TRUE.toString());
 
       TaskStatus status = TaskStatus.newBuilder()
@@ -181,7 +184,7 @@ public class MesosSupervisor implements ISupervisor {
 
     @Override
     public void error(ExecutorDriver driver, String msg) {
-      LOG.error("Received fatal error \nmsg:" + msg + "\nHalting process...");
+      LOG.error("Received fatal error \nmsg: {} \nHalting process...", msg);
       Runtime.getRuntime().halt(2);
     }
 
@@ -212,13 +215,13 @@ public class MesosSupervisor implements ISupervisor {
             _lastTime = now;
           }
           if ((now - _lastTime) > 1000L * _timeoutSecs) {
-            LOG.info("Supervisor has not had anything assigned for " + _timeoutSecs + " secs. Committing suicide...");
+            LOG.info("Supervisor has not had anything assigned for {} secs. Committing suicide...", _timeoutSecs);
             Runtime.getRuntime().halt(0);
           }
           Utils.sleep(5000);
         }
       } catch (Throwable t) {
-        LOG.error(t);
+        LOG.error(t.getMessage());
         Runtime.getRuntime().halt(2);
       }
     }

--- a/storm/src/main/storm/mesos/NimbusScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusScheduler.java
@@ -17,12 +17,20 @@
  */
 package storm.mesos;
 
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.ExecutorID;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.MasterInfo;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.SlaveID;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import static storm.mesos.PrettyProtobuf.taskStatusToString;
@@ -30,7 +38,7 @@ import static storm.mesos.PrettyProtobuf.taskStatusToString;
 public class NimbusScheduler implements Scheduler {
   private MesosNimbus mesosNimbus;
   private CountDownLatch _registeredLatch = new CountDownLatch(1);
-  public static final Logger LOG = Logger.getLogger(MesosNimbus.class);
+  public static final Logger LOG = LoggerFactory.getLogger(MesosNimbus.class);
 
   public NimbusScheduler(MesosNimbus mesosNimbus) {
     this.mesosNimbus = mesosNimbus;
@@ -58,7 +66,7 @@ public class NimbusScheduler implements Scheduler {
 
   @Override
   public void error(SchedulerDriver driver, String msg) {
-    LOG.error("Received fatal error \nmsg:" + msg + "\nHalting process...");
+    LOG.error("Received fatal error \nmsg: {} \nHalting process...", msg);
     try {
       mesosNimbus.shutdown();
     } catch (Exception e) {
@@ -74,13 +82,13 @@ public class NimbusScheduler implements Scheduler {
 
   @Override
   public void offerRescinded(SchedulerDriver driver, OfferID id) {
-    LOG.info("Offer rescinded. offerId: " + id.getValue());
+    LOG.info("Offer rescinded. offerId: {}", id.getValue());
     mesosNimbus.offerRescinded(id);
   }
 
   @Override
   public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
-    LOG.debug("Received status update: " + taskStatusToString(status));
+    LOG.debug("Received status update: {}", taskStatusToString(status));
     switch (status.getState()) {
       case TASK_FINISHED:
       case TASK_FAILED:
@@ -100,12 +108,11 @@ public class NimbusScheduler implements Scheduler {
 
   @Override
   public void slaveLost(SchedulerDriver driver, SlaveID id) {
-    LOG.warn("Lost slave id: " + id.getValue());
+    LOG.warn("Lost slave id: {}", id.getValue());
   }
 
   @Override
   public void executorLost(SchedulerDriver driver, ExecutorID executor, SlaveID slave, int status) {
-    LOG.warn("Mesos Executor lost: executor: " + executor.getValue() +
-        " slave: " + slave.getValue() + " status: " + status);
+    LOG.warn("Mesos Executor lost: executor: {} slave: {} status: {}", executor.getValue(), slave.getValue(), status);
   }
 }

--- a/storm/src/main/storm/mesos/PrettyProtobuf.java
+++ b/storm/src/main/storm/mesos/PrettyProtobuf.java
@@ -20,13 +20,21 @@ package storm.mesos;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.Protos.Value.Range;
 import org.apache.mesos.Protos.Value.Ranges;
 import org.apache.mesos.Protos.Value.Set;
 import org.json.simple.JSONValue;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * This utility class provides methods to improve logging of Mesos protobuf objects.

--- a/storm/src/main/storm/mesos/ResourceRoleComparator.java
+++ b/storm/src/main/storm/mesos/ResourceRoleComparator.java
@@ -17,7 +17,7 @@
  */
 package storm.mesos;
 
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.Resource;
 
 import java.util.Comparator;
 

--- a/storm/src/main/storm/mesos/RotatingMap.java
+++ b/storm/src/main/storm/mesos/RotatingMap.java
@@ -17,7 +17,13 @@
  */
 package storm.mesos;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 /**

--- a/storm/src/main/storm/mesos/TaskAssignments.java
+++ b/storm/src/main/storm/mesos/TaskAssignments.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package storm.mesos;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.mesos.Protos.TaskID;
+
+/**
+ * Tracks the Mesos Tasks / Storm Worker Processes that have been assigned
+ * to this MesosSupervisor instance.
+ *
+ * Serves as a bridge between the storm-core supervisor logic and the
+ * mesos executor logic.
+ *
+ * Tasks are assigned or removed via either:
+ *   Storm (storm-core supervisor) calling MesosSupervisor's ISupervisor interfaces
+ *   Mesos (mesos executor driver) calling MesosSupervisor's Executor interfaces
+ *
+ * This abstraction allows the MesosSupervisor code to stay a bit tighter and cleaner,
+ * while still giving the power to track the TaskID across deactivation of a port.
+ * That allows calls through the Mesos interfaces to deactivate a port and then have
+ * the storm-core supervisor see that the port is no longer active (via false return from
+ * ISupervisor.confirmAssigned), and thus drives the storm-core supervisor to kill the
+ * worker process associated with the port.
+ */
+public enum TaskAssignments {
+  INSTANCE; // This is a singleton class; see Effective Java (2nd Edition): Item 3
+
+  // Alternative to a constructor for this enum-based singleton
+  public static TaskAssignments getInstance() {
+    return INSTANCE;
+  }
+
+  private enum TaskState {
+    ACTIVE,
+    INACTIVE
+  }
+
+  private static class AssignmentInfo {
+    public final TaskID taskId;
+    public final TaskState taskState;
+
+    public AssignmentInfo(TaskID taskId, TaskState taskState) {
+      this.taskId = taskId;
+      this.taskState = taskState;
+    }
+  }
+
+  // Map of ports to their assigned tasks' info.
+  private final Map<Integer, AssignmentInfo> portAssignments = new ConcurrentHashMap<>();
+
+  public Set<Integer> getAssignedPorts() {
+    return portAssignments.keySet();
+  }
+
+  /**
+   * Signal to the storm-core supervisor that this task should be started.
+   */
+  public int register(TaskID taskId) throws IllegalArgumentException {
+    int port = MesosCommon.portFromTaskId(taskId.getValue());
+    AssignmentInfo existingAssignment = portAssignments.get(port);
+    if (existingAssignment != null) {
+      throw new IllegalArgumentException("Refusing to register task " + taskId.getValue() +
+                        " because its port " + port + " is already registered for task " +
+                        existingAssignment.taskId.getValue());
+    }
+    portAssignments.put(port, new AssignmentInfo(taskId, TaskState.ACTIVE));
+    return port;
+  }
+
+  /**
+   * This task has been killed by the storm-core supervisor, ditch all
+   * knowledge of it.
+   */
+  public TaskID deregister(int port) {
+    AssignmentInfo assignment = portAssignments.remove(port);
+    if (assignment != null) {
+      return assignment.taskId;
+    }
+    return null;
+  }
+
+  /**
+   * Is this port active? (And thus also registered?)
+   *
+   * Used by storm-core supervisor to determine if a worker process should be
+   * launched or killed on the specified port.
+   */
+  public boolean confirmAssigned(int port) {
+    AssignmentInfo assignment = portAssignments.get(port);
+    if (assignment != null) {
+      return (assignment.taskState == TaskState.ACTIVE);
+    }
+    return false;
+  }
+
+  /**
+   * Signal to the storm-core supervisor that this task should be killed.
+   *
+   * This method provides a way for Mesos (well, calls routed through Mesos to the Executor
+   * interface implemented by MesosSupervisor) to kill the worker processes (mesos tasks).
+   *
+   * This works by changing the state of an existing assignment from active to inactive,
+   * thus signaling to the storm-core supervisor that the assignment is no longer active.
+   * And that works by the storm-core supervisor checking the active/inactive state via a
+   * periodic call to ISupervisor.confirmAssigned(), which calls TaskAssignments.confirmAssigned().
+   * Notably, we must retain *some* knowledge about the assignment despite it being deactivated,
+   * namely the TaskID, so that when the storm-core supervisor calls ISupervisor.killedWorker()
+   * we can send a TASK_FINISHED TaskStatus update to Mesos. That is required for Mesos to
+   * learn of the task having been killed, otherwise Mesos would think the task is still running.
+   *
+   * NOTE: This isn't used *yet*, as we haven't spent time to code and test
+   * MesosSupervisor.killTask() and MesosSupervisor.shutdown().
+   */
+  public int deactivate(TaskID taskId) throws IllegalArgumentException {
+    int port = MesosCommon.portFromTaskId(taskId.getValue());
+    AssignmentInfo assignment = portAssignments.get(port);
+    if (assignment != null) {
+      portAssignments.put(port, new AssignmentInfo(taskId, TaskState.INACTIVE));
+      return port;
+    }
+    return 0;
+  }
+
+}

--- a/storm/src/main/storm/mesos/TaskAssignments.java
+++ b/storm/src/main/storm/mesos/TaskAssignments.java
@@ -17,6 +17,7 @@
  */
 package storm.mesos;
 
+import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -54,9 +55,11 @@ public enum TaskAssignments {
     INACTIVE
   }
 
-  private static class AssignmentInfo {
-    public final TaskID taskId;
-    public final TaskState taskState;
+  // NOTE: this doesn't *really* need to be Serializable -- this is only done to avoid
+  // an exception thrown during mk-supervisor if the ISupervisor object isn't serializable.
+  private static class AssignmentInfo implements Serializable {
+    public final transient TaskID taskId;
+    public final transient TaskState taskState;
 
     public AssignmentInfo(TaskID taskId, TaskState taskState) {
       this.taskId = taskId;

--- a/storm/src/main/storm/mesos/logviewer/LogViewerController.java
+++ b/storm/src/main/storm/mesos/logviewer/LogViewerController.java
@@ -19,7 +19,8 @@ package storm.mesos.logviewer;
 
 import backtype.storm.Config;
 import com.google.common.base.Optional;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,7 +30,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 public class LogViewerController {
-  private static final Logger LOG = Logger.getLogger(LogViewerController.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LogViewerController.class);
   protected Process process;
   protected SocketUrlDetection urlDetector;
   protected Integer port;

--- a/storm/src/main/storm/mesos/logviewer/SocketUrlDetection.java
+++ b/storm/src/main/storm/mesos/logviewer/SocketUrlDetection.java
@@ -18,15 +18,15 @@
 package storm.mesos.logviewer;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
-import java.net.UnknownHostException;
 
 public class SocketUrlDetection {
-  private static final Logger LOG = Logger.getLogger(SocketUrlDetection.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SocketUrlDetection.class);
   protected Integer port;
 
   public SocketUrlDetection(Integer port) {
@@ -37,13 +37,13 @@ public class SocketUrlDetection {
     Socket socket = null;
     boolean reachable = false;
     try {
-      LOG.info("Checking host " + InetAddress.getLocalHost() + " and port " + getPort());
+      LOG.info("Checking host {} and port {}", InetAddress.getLocalHost(), getPort());
 
       socket = new Socket(InetAddress.getLocalHost(), getPort());
       reachable = true;
     } catch (IOException e) {
       // don't care.
-      LOG.warn(e);
+      LOG.warn(e.getMessage());
     } finally {
       IOUtils.closeQuietly(socket);
     }

--- a/storm/src/test/storm/mesos/MesosNimbusTest.java
+++ b/storm/src/test/storm/mesos/MesosNimbusTest.java
@@ -22,12 +22,21 @@ import backtype.storm.scheduler.Topologies;
 import backtype.storm.scheduler.TopologyDetails;
 import backtype.storm.scheduler.WorkerSlot;
 import org.apache.mesos.MesosSchedulerDriver;
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.SlaveID;
+import org.apache.mesos.Protos.Value;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 

--- a/storm/src/test/storm/mesos/OfferRoleComparatorTest.java
+++ b/storm/src/test/storm/mesos/OfferRoleComparatorTest.java
@@ -17,14 +17,20 @@
  */
 package storm.mesos;
 
-import static org.junit.Assert.*;
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.SlaveID;
+import org.apache.mesos.Protos.Value;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class OfferRoleComparatorTest {
 


### PR DESCRIPTION
This is needed to avoid a problem with mesos-slave recovery resulting in LOST tasks.

i.e., we discovered that if you relaunch a topology's task onto the same worker slot (so there are 2 different instances with the same "task ID" that have run), then when the mesos-slave process is recovering, it terminates the task upon finding a "terminal" update in the recorded state of the task. The terminal state having been recorded the 1st time the task with that task ID stopped.

To solve this we ensure all task IDs are unique, by adding a milisecond-granularity timestamp onto the task IDs.