### PR TITLE
Bug fix - Prevent losing logs due to incorrect shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,18 @@
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>1.6.6</version>
+        <exclusions>
+        <!-- slf4j-api is provided by storm-core. We might as well
+               use the one that is provided to us by storm rather than including
+               the slf4j-api classes in the jar.
+               WARNING: Please do *not* shade org.slf4j. Classes from org.slf4j
+                        are referenced within log4j-over-slf4j and shading them
+                        would lead to java.lang.NoClassDefFoundError -->
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.mortbay.jetty</groupId>

--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -70,6 +70,19 @@
             </filter>
           </filters>
           <relocations>
+          <!-- List of dependencies that should not be shaded
+                 1. org.slf4j:
+                     shading org.slf4j would lead to a couple of issues:
+                     a) Shading org.slf4j corresponding to slf4j-api would prevent its classes
+                        from binding to the concrete implementations that the storm's
+                        logging libraries provide. Eg. org.slf4j.Logger interface in slf4j-api
+                        becomes org.slf4j.shaded.Logger and none of the Logger implementations
+                        provided by storm would implement org.slf4j.shaded.Logger. This in turn
+                        would lead slf4j-api to bind to NOPLogger resulting in loss of application
+                        logs.
+                     b) Classes from org.slf4j are referenced within slf4j bridge artifacts like
+                        'log4j-over-slf4j'. So shading them would cause MesosNimbus to throw
+                        java.lang.NoClassDefFoundError -->
             <relocation>
               <pattern>com.google.common</pattern>
               <shadedPattern>com.google.common.shaded</shadedPattern>
@@ -81,10 +94,6 @@
             <relocation>
               <pattern>org.apache.commons</pattern>
               <shadedPattern>com.apache.commons.shaded</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>org.slf4j</pattern>
-              <shadedPattern>org.slf4j.shaded</shadedPattern>
             </relocation>
             <relocation>
               <pattern>org.apache.log4j</pattern>


### PR DESCRIPTION
As mentioned in https://github.com/mesos/storm/issues/102, when we shade org.slf4j, we end up shading all the classes belonging to slf4j-api provided by storm-core. This causes slf4j not to bind to concrete implementation provided by storm-core. Eg. org.slf4j.Logger interface in slf4j-4j becomes org.slf4j.shaded.Logger and none of the Logger in the storm jar would implement org.slf4j.shaded.Logger. Hence all the log operations in the storm/mesos translates to NOP's. This PR aims to fix it.