### PR TITLE
log4j-over-slf4j to slf4j migration

### DIFF
--- a/storm-shim-9x/src/main/java/storm/mesos/shims/LocalStateShim.java
+++ b/storm-shim-9x/src/main/java/storm/mesos/shims/LocalStateShim.java
@@ -18,7 +18,8 @@
 package storm.mesos.shims;
 
 import backtype.storm.utils.LocalState;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -26,7 +27,7 @@ import java.util.Map;
 
 public class LocalStateShim implements ILocalStateShim {
   LocalState _state;
-  private static final Logger LOG = Logger.getLogger(LocalStateShim.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LocalStateShim.class);
 
   public LocalStateShim(String localDir) throws IOException {
     _state = new LocalState(localDir);

--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -166,7 +166,8 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.18</version>
     </dependency>
     <dependency>
       <groupId>org.mortbay.jetty</groupId>

--- a/storm/src/main/storm/mesos/LocalFileServer.java
+++ b/storm/src/main/storm/mesos/LocalFileServer.java
@@ -18,7 +18,6 @@
 package storm.mesos;
 
 import com.google.common.base.Optional;
-import org.apache.log4j.Logger;
 import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Handler;
 import org.mortbay.jetty.Server;
@@ -26,6 +25,8 @@ import org.mortbay.jetty.handler.ContextHandler;
 import org.mortbay.jetty.handler.HandlerList;
 import org.mortbay.jetty.handler.ResourceHandler;
 import org.mortbay.jetty.nio.SelectChannelConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.URI;
@@ -37,7 +38,7 @@ import java.net.URI;
 
 public class LocalFileServer {
 
-  public static final Logger LOG = Logger.getLogger(LocalFileServer.class);
+  public static final Logger LOG = LoggerFactory.getLogger(LocalFileServer.class);
   private Server _server = new Server();
 
   public static void main(String[] args) throws Exception {
@@ -59,7 +60,7 @@ public class LocalFileServer {
   public URI serveDir(String uriPath, String filePath, Optional<Integer> port) throws Exception {
 
     if (port.isPresent()) {
-      LOG.info("Starting local file server on port: " + port.get());
+      LOG.info("Starting local file server on port: {}", port.get());
       _server = new Server(port.get());
     } else {
       _server = new Server();

--- a/storm/src/main/storm/mesos/MesosCommon.java
+++ b/storm/src/main/storm/mesos/MesosCommon.java
@@ -19,12 +19,14 @@ package storm.mesos;
 
 import backtype.storm.scheduler.TopologyDetails;
 import com.google.common.base.Optional;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MesosCommon {
-  public static final Logger LOG = Logger.getLogger(MesosCommon.class);
+  public static final Logger LOG = LoggerFactory.getLogger(MesosCommon.class);
 
   public static final String WORKER_CPU_CONF = "topology.mesos.worker.cpu";
   public static final String WORKER_MEM_CONF = "topology.mesos.worker.mem.mb";
@@ -51,7 +53,7 @@ public class MesosCommon {
   public static String hostFromAssignmentId(String assignmentId, String delimiter) {
     final int last = assignmentId.lastIndexOf(delimiter);
     String host = assignmentId.substring(last + delimiter.length());
-    LOG.debug("assignmentId=" + assignmentId + " host=" + host);
+    LOG.debug("assignmentId={} host={}", assignmentId, host);
     return host;
   }
 

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -274,7 +274,7 @@ public class MesosNimbus implements INimbus {
                     offer.getHostname(), offer.getId().getValue());
           _offers.put(offer.getId(), offer);
         } else {
-          LOG.debug("resourceOffers: Declining offer from host: {} offerId: {}",
+          LOG.debug("resourceOffers: Declining offer from host: {}, offerId: {}",
                     offer.getHostname(), offer.getId().getValue());
           driver.declineOffer(offer.getId());
         }
@@ -448,8 +448,6 @@ public class MesosNimbus implements INimbus {
   public Collection<WorkerSlot> allSlotsAvailableForScheduling(
       Collection<SupervisorDetails> existingSupervisors, Topologies topologies, Set<String> topologiesMissingAssignments) {
     synchronized (_offersLock) {
-      LOG.debug("allSlotsAvailableForScheduling: Currently have " + _offers.size() + " offers buffered" +
-                (_offers.size() > 0 ? (":" + offerMapToString(_offers)) : ""));
       LOG.debug("allSlotsAvailableForScheduling: Currently have {} offers buffered {}",
                 _offers.size(), (_offers.size() > 0 ? (":" + offerMapToString(_offers)) : ""));
       if (!topologiesMissingAssignments.isEmpty()) {

--- a/storm/src/main/storm/mesos/MesosSupervisor.java
+++ b/storm/src/main/storm/mesos/MesosSupervisor.java
@@ -146,7 +146,7 @@ public class MesosSupervisor implements ISupervisor {
 
     @Override
     public void registered(ExecutorDriver driver, ExecutorInfo executorInfo, FrameworkInfo frameworkInfo, SlaveInfo slaveInfo) {
-      LOG.info("Received executor data < {} >", executorInfo.getData().toStringUtf8());
+      LOG.info("Received executor data <{}>", executorInfo.getData().toStringUtf8());
       Map ids = (Map) JSONValue.parse(executorInfo.getData().toStringUtf8());
       _id = (String) ids.get(MesosCommon.SUPERVISOR_ID);
       _assignmentId = (String) ids.get(MesosCommon.ASSIGNMENT_ID);

--- a/storm/src/main/storm/mesos/NimbusScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusScheduler.java
@@ -17,12 +17,20 @@
  */
 package storm.mesos;
 
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.ExecutorID;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.MasterInfo;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.SlaveID;
+import org.apache.mesos.Protos.TaskID;
+import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import static storm.mesos.PrettyProtobuf.taskStatusToString;
@@ -30,7 +38,7 @@ import static storm.mesos.PrettyProtobuf.taskStatusToString;
 public class NimbusScheduler implements Scheduler {
   private MesosNimbus mesosNimbus;
   private CountDownLatch _registeredLatch = new CountDownLatch(1);
-  public static final Logger LOG = Logger.getLogger(MesosNimbus.class);
+  public static final Logger LOG = LoggerFactory.getLogger(MesosNimbus.class);
 
   public NimbusScheduler(MesosNimbus mesosNimbus) {
     this.mesosNimbus = mesosNimbus;
@@ -58,7 +66,7 @@ public class NimbusScheduler implements Scheduler {
 
   @Override
   public void error(SchedulerDriver driver, String msg) {
-    LOG.error("Received fatal error \nmsg:" + msg + "\nHalting process...");
+    LOG.error("Received fatal error \nmsg: {} \nHalting process...", msg);
     try {
       mesosNimbus.shutdown();
     } catch (Exception e) {
@@ -74,13 +82,13 @@ public class NimbusScheduler implements Scheduler {
 
   @Override
   public void offerRescinded(SchedulerDriver driver, OfferID id) {
-    LOG.info("Offer rescinded. offerId: " + id.getValue());
+    LOG.info("Offer rescinded. offerId: {}", id.getValue());
     mesosNimbus.offerRescinded(id);
   }
 
   @Override
   public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
-    LOG.debug("Received status update: " + taskStatusToString(status));
+    LOG.debug("Received status update: {}", taskStatusToString(status));
     switch (status.getState()) {
       case TASK_FINISHED:
       case TASK_FAILED:
@@ -100,12 +108,11 @@ public class NimbusScheduler implements Scheduler {
 
   @Override
   public void slaveLost(SchedulerDriver driver, SlaveID id) {
-    LOG.warn("Lost slave id: " + id.getValue());
+    LOG.warn("Lost slave id: {}", id.getValue());
   }
 
   @Override
   public void executorLost(SchedulerDriver driver, ExecutorID executor, SlaveID slave, int status) {
-    LOG.warn("Mesos Executor lost: executor: " + executor.getValue() +
-        " slave: " + slave.getValue() + " status: " + status);
+    LOG.warn("Mesos Executor lost: executor: {} slave: {} status: {}", executor.getValue(), slave.getValue(), status);
   }
 }

--- a/storm/src/main/storm/mesos/PrettyProtobuf.java
+++ b/storm/src/main/storm/mesos/PrettyProtobuf.java
@@ -20,13 +20,21 @@ package storm.mesos;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.Protos.Value.Range;
 import org.apache.mesos.Protos.Value.Ranges;
 import org.apache.mesos.Protos.Value.Set;
 import org.json.simple.JSONValue;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * This utility class provides methods to improve logging of Mesos protobuf objects.

--- a/storm/src/main/storm/mesos/ResourceRoleComparator.java
+++ b/storm/src/main/storm/mesos/ResourceRoleComparator.java
@@ -17,7 +17,7 @@
  */
 package storm.mesos;
 
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.Resource;
 
 import java.util.Comparator;
 

--- a/storm/src/main/storm/mesos/RotatingMap.java
+++ b/storm/src/main/storm/mesos/RotatingMap.java
@@ -17,7 +17,13 @@
  */
 package storm.mesos;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 /**

--- a/storm/src/main/storm/mesos/logviewer/LogViewerController.java
+++ b/storm/src/main/storm/mesos/logviewer/LogViewerController.java
@@ -19,7 +19,8 @@ package storm.mesos.logviewer;
 
 import backtype.storm.Config;
 import com.google.common.base.Optional;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,7 +30,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 
 public class LogViewerController {
-  private static final Logger LOG = Logger.getLogger(LogViewerController.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LogViewerController.class);
   protected Process process;
   protected SocketUrlDetection urlDetector;
   protected Integer port;

--- a/storm/src/main/storm/mesos/logviewer/SocketUrlDetection.java
+++ b/storm/src/main/storm/mesos/logviewer/SocketUrlDetection.java
@@ -18,15 +18,15 @@
 package storm.mesos.logviewer;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
-import java.net.UnknownHostException;
 
 public class SocketUrlDetection {
-  private static final Logger LOG = Logger.getLogger(SocketUrlDetection.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SocketUrlDetection.class);
   protected Integer port;
 
   public SocketUrlDetection(Integer port) {
@@ -37,13 +37,13 @@ public class SocketUrlDetection {
     Socket socket = null;
     boolean reachable = false;
     try {
-      LOG.info("Checking host " + InetAddress.getLocalHost() + " and port " + getPort());
+      LOG.info("Checking host {} and port {}", InetAddress.getLocalHost(), getPort());
 
       socket = new Socket(InetAddress.getLocalHost(), getPort());
       reachable = true;
     } catch (IOException e) {
       // don't care.
-      LOG.warn(e);
+      LOG.warn(e.getMessage());
     } finally {
       IOUtils.closeQuietly(socket);
     }

--- a/storm/src/test/storm/mesos/MesosNimbusTest.java
+++ b/storm/src/test/storm/mesos/MesosNimbusTest.java
@@ -22,12 +22,21 @@ import backtype.storm.scheduler.Topologies;
 import backtype.storm.scheduler.TopologyDetails;
 import backtype.storm.scheduler.WorkerSlot;
 import org.apache.mesos.MesosSchedulerDriver;
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.SlaveID;
+import org.apache.mesos.Protos.Value;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 

--- a/storm/src/test/storm/mesos/OfferRoleComparatorTest.java
+++ b/storm/src/test/storm/mesos/OfferRoleComparatorTest.java
@@ -17,14 +17,20 @@
  */
 package storm.mesos;
 
-import static org.junit.Assert.*;
-import org.apache.mesos.Protos.*;
+import org.apache.mesos.Protos.FrameworkID;
+import org.apache.mesos.Protos.Offer;
+import org.apache.mesos.Protos.OfferID;
+import org.apache.mesos.Protos.Resource;
+import org.apache.mesos.Protos.SlaveID;
+import org.apache.mesos.Protos.Value;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class OfferRoleComparatorTest {
 


### PR DESCRIPTION
Two reasons we should do this
      1. Its best to use `sfl4j` directly rather than use `log4j-over-slf4j`
      2. `slf4j` provides better log event formatting than log4j

      