### PR TITLE
onbuild triggers for mesos/storm versioning and building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,21 +11,19 @@ ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
 
-ARG MESOS_RELEASE=0.27.0
-ARG STORM_RELEASE=0.9.6
-ARG MIRROR=http://www.gtlib.gatech.edu/pub
+ONBUILD ARG MESOS_RELEASE=0.27.0
+ONBUILD ARG STORM_RELEASE=0.9.6
+ONBUILD ARG MIRROR=http://www.gtlib.gatech.edu/pub
 
-ADD . /work
-
-WORKDIR /work
+ADD . /tmp
 
 RUN apt-get update && \
-  apt-get install -y openjdk-7-jdk maven wget && \
-  ./bin/build-release.sh main && \
-  mkdir -p /opt/storm && \
-  tar xf storm-mesos-*.tgz -C /opt/storm --strip=1 && \
-  rm -rf /work ~/.m2 && \
-  apt-get -yf autoremove openjdk-7-jdk maven && \
-  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  apt-get install -y openjdk-7-jdk maven wget
+ONBUILD RUN cd /tmp && ./bin/build-release.sh main && \
+            mkdir -p /opt/storm && \
+            tar xf /tmp/storm-mesos-*.tgz -C /opt/storm --strip=1 && \
+            rm -rf /tmp/* ~/.m2 && \
+            apt-get -yf autoremove openjdk-7-jdk maven && \
+            apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /opt/storm

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,19 +11,21 @@ ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
 
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
 
-ONBUILD ARG MESOS_RELEASE=0.27.0
-ONBUILD ARG STORM_RELEASE=0.9.6
-ONBUILD ARG MIRROR=http://www.gtlib.gatech.edu/pub
+ARG MESOS_RELEASE=0.27.0
+ARG STORM_RELEASE=0.9.6
+ARG MIRROR=http://www.gtlib.gatech.edu/pub
 
-ADD . /tmp
+ADD . /work
+
+WORKDIR /work
 
 RUN apt-get update && \
-  apt-get install -y openjdk-7-jdk maven wget
-ONBUILD RUN cd /tmp && ./bin/build-release.sh main && \
-            mkdir -p /opt/storm && \
-            tar xf /tmp/storm-mesos-*.tgz -C /opt/storm --strip=1 && \
-            rm -rf /tmp/* ~/.m2 && \
-            apt-get -yf autoremove openjdk-7-jdk maven && \
-            apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  apt-get install -y openjdk-7-jdk maven wget && \
+  ./bin/build-release.sh main && \
+  mkdir -p /opt/storm && \
+  tar xf storm-mesos-*.tgz -C /opt/storm --strip=1 && \
+  rm -rf /work ~/.m2 && \
+  apt-get -yf autoremove openjdk-7-jdk maven && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /opt/storm

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -1,0 +1,29 @@
+#
+# Dockerfile for Storm Mesos framework
+#
+FROM mesosphere/mesos:0.27.0-0.2.190.ubuntu1404
+MAINTAINER Timothy Chen <tnachen@gmail.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# export environment
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+
+ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
+
+ONBUILD ARG MESOS_RELEASE=0.27.0
+ONBUILD ARG STORM_RELEASE=0.9.6
+ONBUILD ARG MIRROR=http://www.gtlib.gatech.edu/pub
+
+ADD . /tmp
+
+RUN apt-get update && \
+  apt-get install -y openjdk-7-jdk maven wget
+ONBUILD RUN cd /tmp && ./bin/build-release.sh main && \
+            mkdir -p /opt/storm && \
+            tar xf /tmp/storm-mesos-*.tgz -C /opt/storm --strip=1 && \
+            rm -rf /tmp/* ~/.m2 && \
+            apt-get -yf autoremove openjdk-7-jdk maven && \
+            apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /opt/storm


### PR DESCRIPTION
By deferring the building of mesos/storm one is able to use mesos/storm image as a base image and then being able to easily control the desired versioning. 
Instead of having to pull the mesos/storm repo and build the container passing the `--build-arg STORM_RELEASE/MESOS_RELEASE` I find more useful to just use an onbuild version of Dockerfile that allow me to simply do on my own dockerfile the following: 

```
FROM mesos/storm-onbuild 
....
<here I added my private things>
.....
```
and then
`docker build -t my_storm_mesos_image --build-arg STORM_RELEASE=0.10.0 .
`
what do you guys think ? 