### PR TITLE
add STORM_URL env variable for using alternate storm binary package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV MESOS_NATIVE_JAVA_LIBRARY /usr/lib/libmesos.so
 ARG MESOS_RELEASE=0.27.0
 ARG STORM_RELEASE=0.9.6
 ARG MIRROR=http://www.gtlib.gatech.edu/pub
+ARG STORM_URL=''
 
 ADD . /work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ADD . /work
 WORKDIR /work
 
 RUN apt-get update && \
-  apt-get install -y openjdk-7-jdk maven wget && \
+  apt-get install -y openjdk-7-jdk maven curl && \
   ./bin/build-release.sh main && \
   mkdir -p /opt/storm && \
   tar xf storm-mesos-*.tgz -C /opt/storm --strip=1 && \

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -21,6 +21,8 @@ fi
 
 MESOS_RELEASE=${MESOS_RELEASE:-`grep -1 -A 0 -B 0 '<mesos.default.version>' pom.xml | head -n 1 | awk '{print $1}' | sed -e 's/.*<mesos.default.version>//' | sed -e 's/<\/mesos.default.version>.*//'`}
 
+STORM_URL=${STORM_URL:-''}
+
 MIRROR=${MIRROR:-"http://www.gtlib.gatech.edu/pub"}
 
 function help {
@@ -40,19 +42,25 @@ Usage: bin/build-release.sh [<storm.tar.gz>]
                               bin/build-release.sh.
 
   ENV
-    MIRROR        Specify Apache Storm Mirror to download from
-                    Default: ${MIRROR}
-    STORM_RELEASE       The targeted release version of Storm
-                    Default: ${STORM_RELEASE}
-    MESOS_RELEASE       The targeted release version of MESOS
-                    Default: ${MESOS_RELEASE}
+    MIRROR          Specify Apache Storm Mirror to download from
+                      Default: ${MIRROR}
+    STORM_RELEASE   The targeted release version of Storm
+                      Default: ${STORM_RELEASE}
+    MESOS_RELEASE   The targeted release version of MESOS
+                      Default: ${MESOS_RELEASE}
+    STORM_URL       Override the URL for downloading the storm binary
+                      NOTE: ensure version matches with STORM_RELEASE
 
 USAGE
 }; function --help { help ;}; function -h { help ;}
 
 function downloadStormRelease {
   if [ ! -f apache-storm-${STORM_RELEASE}.tar.gz ]; then
+    if [ -z ${STORM_URL} ]; then
       wget --progress=dot:mega ${MIRROR}/apache/storm/apache-storm-${STORM_RELEASE}/apache-storm-${STORM_RELEASE}.tar.gz
+    else
+      wget --progress=dot:mega ${STORM_URL}
+    fi
   fi
 }
 
@@ -61,6 +69,7 @@ function clean {
   _rm lib/ classes/
   _rm target
   _rm *mesos*.tgz
+  _rm *storm*tar.gz
 }
 
 function mvnPackage {
@@ -113,6 +122,7 @@ function dockerImage {(
        --build-arg MESOS_RELEASE=$MESOS_RELEASE \
        --build-arg STORM_RELEASE=$STORM_RELEASE \
        --build-arg MIRROR=$MIRROR \
+       --build-arg STORM_URL=$STORM_URL \
         -t mesos/storm:git-`git rev-parse --short HEAD` ."
   echo $cmd
   $cmd

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -57,9 +57,9 @@ USAGE
 function downloadStormRelease {
   if [ ! -f apache-storm-${STORM_RELEASE}.tar.gz ]; then
     if [ -z ${STORM_URL} ]; then
-      wget --progress=dot:mega ${MIRROR}/apache/storm/apache-storm-${STORM_RELEASE}/apache-storm-${STORM_RELEASE}.tar.gz
+      curl -L -O ${MIRROR}/apache/storm/apache-storm-${STORM_RELEASE}/apache-storm-${STORM_RELEASE}.tar.gz
     else
-      wget --progress=dot:mega ${STORM_URL}
+      curl -L -O ${STORM_URL}
     fi
   fi
 }


### PR DESCRIPTION
Support alternate download URL for pre-built storm binary package that is
used to assemble the storm-mesos package.

Initial motivation for this option is to use a patched version of storm-0.9.6
that includes per-topology worker logs (backported from storm 0.10.0).
The release is available here:
* https://github.com/erikdw/storm/releases/tag/v0.9.6-storm-mesos1

So here are some invocations of `bin/build-release.sh` with the alternate storm
package:

non-Docker build:

```
STORM_URL=https://github.com/erikdw/storm/releases/download/v0.9.6-storm-mesos1/apache-storm-0.9.6.tar.gz \
STORM_RELEASE=0.9.6 \
MESOS_RELEASE=0.27.0 \
bin/build-release.sh
```

Docker build:

```
STORM_URL=https://github.com/erikdw/storm/releases/download/v0.9.6-storm-mesos1/apache-storm-0.9.6.tar.gz \
STORM_RELEASE=0.9.6 \
MESOS_RELEASE=0.27.0 \
bin/build-release.sh dockerImage
```