### PR TITLE
logviewer support for configurable storm.log.dir

### DIFF
--- a/storm-shim-10x/src/main/java/storm/mesos/shims/DockerCommandLineShim.java
+++ b/storm-shim-10x/src/main/java/storm/mesos/shims/DockerCommandLineShim.java
@@ -16,12 +16,17 @@
  * limitations under the License.
  */
 package storm.mesos.shims;
+
+import storm.mesos.util.MesosCommon;
+
 import java.util.Map;
 
 public class DockerCommandLineShim implements ICommandLineShim {
+  Map stormConf;
   String extraConfig;
 
-  public DockerCommandLineShim(String extraConfig) {
+  public DockerCommandLineShim(Map stormConf, String extraConfig) {
+    this.stormConf = stormConf;
     this.extraConfig = extraConfig;
   }
 
@@ -34,8 +39,11 @@ public class DockerCommandLineShim implements ICommandLineShim {
         " && export STORM_SUPERVISOR_LOG_FILE=%s-supervisor.log" +
         " && /bin/cp $MESOS_SANDBOX/storm.yaml conf " +
         " && /usr/bin/python bin/storm.py supervisor storm.mesos.MesosSupervisor " +
-        "-c storm.log.dir=$MESOS_SANDBOX/logs%s",
-        javaLibPath, topologyId, extraConfig);
+        "-c storm.log.dir=%s%s",
+        javaLibPath,
+        topologyId,
+        MesosCommon.getStormLogDir(stormConf, "$MESOS_SANDBOX/logs"),
+        extraConfig);
   }
 
 }

--- a/storm-shim-9x/src/main/java/storm/mesos/shims/DockerCommandLineShim.java
+++ b/storm-shim-9x/src/main/java/storm/mesos/shims/DockerCommandLineShim.java
@@ -16,12 +16,17 @@
  * limitations under the License.
  */
 package storm.mesos.shims;
+
+import storm.mesos.util.MesosCommon;
+
 import java.util.Map;
 
 public class DockerCommandLineShim implements ICommandLineShim {
+  Map stormConf;
   String extraConfig;
 
-  public DockerCommandLineShim(String extraConfig) {
+  public DockerCommandLineShim(Map stormConf, String extraConfig) {
+    this.stormConf = stormConf;
     this.extraConfig = extraConfig;
   }
 
@@ -34,7 +39,10 @@ public class DockerCommandLineShim implements ICommandLineShim {
         " && export STORM_SUPERVISOR_LOG_FILE=%s-supervisor.log" +
         " && /bin/cp $MESOS_SANDBOX/storm.yaml conf " +
         " && /usr/bin/python bin/storm supervisor storm.mesos.MesosSupervisor " +
-        "-c storm.log.dir=$MESOS_SANDBOX/logs%s",
-        javaLibPath, topologyId, extraConfig);
+        "-c storm.log.dir=%s%s",
+        javaLibPath,
+        topologyId,
+        MesosCommon.getStormLogDir(stormConf, "$MESOS_SANDBOX/logs"),
+        extraConfig);
   }
 }

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -722,7 +722,7 @@ public class MesosNimbus implements INimbus {
         if (executorPortsResources != null) {
           executorInfoBuilder.addAllResources(executorPortsResources);
         }
-        ICommandLineShim commandLineShim = CommandLineShimFactory.makeCommandLineShim(_container.isPresent(), extraConfig);
+        ICommandLineShim commandLineShim = CommandLineShimFactory.makeCommandLineShim(_conf, _container.isPresent(), extraConfig);
         if (_container.isPresent()) {
           executorInfoBuilder
               .setCommand(CommandInfo.newBuilder()

--- a/storm/src/main/storm/mesos/logviewer/LogViewerController.java
+++ b/storm/src/main/storm/mesos/logviewer/LogViewerController.java
@@ -40,7 +40,7 @@ public class LogViewerController {
   public LogViewerController(Map conf) {
     port = Optional.fromNullable((Number) conf.get(Config.LOGVIEWER_PORT)).or(8000).intValue();
     setUrlDetector(new SocketUrlDetection(port));
-    logDir = MesosCommon.getStormLogDir(conf);
+    logDir = MesosCommon.getStormLogDir(conf, System.getenv("MESOS_SANDBOX") + "/logs");
   }
 
   /**

--- a/storm/src/main/storm/mesos/logviewer/LogViewerController.java
+++ b/storm/src/main/storm/mesos/logviewer/LogViewerController.java
@@ -31,13 +31,19 @@ import java.util.Map;
 
 public class LogViewerController {
   private static final Logger LOG = LoggerFactory.getLogger(LogViewerController.class);
+  private static final String STORM_LOG_DIR_CONF = "storm.log.dir";
   protected Process process;
   protected SocketUrlDetection urlDetector;
   protected Integer port;
+  protected String logdir;
 
   public LogViewerController(Map conf) {
     port = Optional.fromNullable((Number) conf.get(Config.LOGVIEWER_PORT)).or(8000).intValue();
     setUrlDetector(new SocketUrlDetection(port));
+    logdir = System.getenv("MESOS_SANDBOX") + "/logs";
+    if (conf.containsKey(STORM_LOG_DIR_CONF)) {
+      logdir = (String) conf.get(STORM_LOG_DIR_CONF);
+    }
   }
 
   /**
@@ -96,7 +102,7 @@ public class LogViewerController {
         Paths.get(System.getProperty("user.dir"), "/bin/storm").toString(),
         "logviewer",
         "-c",
-        "storm.log.dir=" + System.getenv("MESOS_SANDBOX") + "/logs",
+        "storm.log.dir=" + logdir,
         "-c",
         Config.LOGVIEWER_PORT + "=" + port
     );

--- a/storm/src/main/storm/mesos/shims/CommandLineShimFactory.java
+++ b/storm/src/main/storm/mesos/shims/CommandLineShimFactory.java
@@ -23,9 +23,9 @@ public final class CommandLineShimFactory {
 
   }
 
-  public static ICommandLineShim makeCommandLineShim(boolean docker, String extraConfig) {
+  public static ICommandLineShim makeCommandLineShim(boolean docker, Map stormConf, String extraConfig) {
     if (docker) {
-      return new DockerCommandLineShim(extraConfig);
+      return new DockerCommandLineShim(stormConf, extraConfig);
     } else {
       return new CommandLineShim(extraConfig);
     }

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -39,6 +39,7 @@ public class MesosCommon {
   public static final String WORKER_NAME_PREFIX = "topology.mesos.worker.prefix";
   public static final String WORKER_NAME_PREFIX_DELIMITER = "topology.mesos.worker.prefix.delimiter";
   public static final String MESOS_COMPONENT_NAME_DELIMITER = "topology.mesos.component.name.delimiter";
+  public static final String STORM_LOG_DIR_CONF = "storm.log.dir";
 
   public static final double DEFAULT_WORKER_CPU = 1;
   public static final double DEFAULT_WORKER_MEM_MB = 1000;
@@ -50,6 +51,14 @@ public class MesosCommon {
   public static final String ASSIGNMENT_ID = "assignmentid";
   public static final String DEFAULT_WORKER_NAME_PREFIX_DELIMITER = "_";
   public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = " | ";
+
+  public static String getStormLogDir(Map conf) {
+    if (conf.containsKey(STORM_LOG_DIR_CONF)) {
+      return (String) conf.get(STORM_LOG_DIR_CONF);
+    } else {
+      return System.getenv("MESOS_SANDBOX") + "/logs";
+    }
+  }
 
   public static String hostFromAssignmentId(String assignmentId, String delimiter) {
     final int last = assignmentId.lastIndexOf(delimiter);

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -52,11 +52,11 @@ public class MesosCommon {
   public static final String DEFAULT_WORKER_NAME_PREFIX_DELIMITER = "_";
   public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = " | ";
 
-  public static String getStormLogDir(Map conf) {
+  public static String getStormLogDir(Map conf, String defaultLogDir) {
     if (conf.containsKey(STORM_LOG_DIR_CONF)) {
       return (String) conf.get(STORM_LOG_DIR_CONF);
     } else {
-      return System.getenv("MESOS_SANDBOX") + "/logs";
+      return defaultLogDir;
     }
   }
 


### PR DESCRIPTION
but fall back to hardcoded mesos-sandbox path.

Notably, `storm.log.dir` is the configuration parameter in storm for choosing the log directory to be used (it's set in the [logback (storm-0.9.x)](https://github.com/apache/storm/blob/v0.9.6/logback/cluster.xml#L21) & [log4j 2 (storm-0.10.0+)](https://github.com/apache/storm/blob/master/log4j2/cluster.xml#L25) config files).
