### PR TITLE
Add support for building storm-mesos docker images based on storm, mesos versions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+!storm-mesos-*.tgz
+.idea
+.vimrc
+*.swp
+_release
+build
+target
+*.iml
+*.zip
+*.tgz
+*.tar.gz
+dependency-reduced-pom.xml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+#
+# Makefile for building storm-mesos docker images
+#
+# make help
+#
+#
+RELEASE ?= `grep -1 -A 0 -B 0 '<version>' pom.xml | head -n 1 | awk '{print $1}' | sed -e 's/.*<version>//' | sed -e 's/<\/version>.*//'`
+DOCKER_REPO ?= mesos
+MIRROR ?=
+STORM_URL ?=
+JAVA_PRODUCT_VERSION ?= 7
+
+all: help
+
+help:
+	@echo 'Options available:'
+	@echo '  make images STORM_RELEASE=0.10.0 MESOS_RELEASE=0.28.0 DOCKER_REPO=mesos'
+	@echo '  make push   STORM_RELEASE=0.10.0 MESOS_RELEASE=0.28.0 DOCKER_REPO=mesos'
+	@echo ''
+	@echo 'ENV'
+	@echo '  STORM_RELEASE          The targeted release version of Storm'
+	@echo '                             Default: 0.10.0'
+	@echo '  MESOS_RELEASE          The targeted release version of MESOS'
+	@echo '                             Default: 0.28.0'
+	@echo '  DOCKER_REPO            The docker repo for which to build the docker image'
+	@echo '                             Default: mesos'
+	@echo '  RELEASE                The targeted release version of Storm'
+	@echo '                             Default: current version in pom.xml'
+	@echo '  JAVA_PRODUCT_VERSION   The java product version to use in the docker image'
+	@echo '                             Default: 7'
+	@echo '  MIRROR                 Where to download the apache storm packages'
+	@echo '                             Default: http://www.gtlib.gatech.edu/pub'
+	@echo '  STORM_URL              The url to use to download the apache storm packages'
+	@echo '                             Default: $$MIRROR/apache/storm/apache-storm-$$STORM_RELEASE/apache-storm-$$STORM_RELEASE.tar.gz'
+
+check-version:
+ifndef STORM_RELEASE
+	@echo "Error: STORM_RELEASE is undefined."
+	@make --no-print-directory help
+	@exit 1
+endif
+ifndef MESOS_RELEASE
+	@echo "Error: MESOS_RELEASE is undefined."
+	@make --no-print-directory help
+	@exit 1
+endif
+
+images: check-version
+	docker build \
+		--rm \
+		--build-arg STORM_RELEASE=$(STORM_RELEASE) \
+       	--build-arg MESOS_RELEASE=$(MESOS_RELEASE) \
+       	--build-arg RELEASE=$(RELEASE) \
+       	--build-arg JAVA_PRODUCT_VERSION=$(JAVA_PRODUCT_VERSION) \
+       	--build-arg MIRROR=$(MIRROR) \
+       	--build-arg STORM_URL=$(STORM_URL) \
+		-t $(DOCKER_REPO)/storm-mesos:$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION) .
+	docker build \
+		--rm \
+		-f onbuild/Dockerfile \
+		-t $(DOCKER_REPO)/storm-mesos:$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION)-onbuild .
+
+push: check-version
+	docker push $(DOCKER_REPO)/storm-mesos:$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION)
+	docker push $(DOCKER_REPO)/storm-mesos:$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION)-onbuild

--- a/README.md
+++ b/README.md
@@ -58,11 +58,36 @@ bin/build-release.sh downloadStormRelease
 * `dockerImage`
 
   Builds a Docker image from the current code.
-  * Notably, the mesos/storm repo on Github also has a hook that auomatically builds a [new Docker image on Dockerhub](https://hub.docker.com/r/mesosphere/storm/) upon every commit.
 
 * `help`
 
   Prints out usage information about the build-release.sh script.
+
+## Docker images Building
+
+In order to build the storm-mesos docker image, or a docker image ready to be used as ``mesos.container.docker.image`` in your storm configuration, run the following:
+
+```shell
+make help
+make images STORM_RELEASE=0.X.X MESOS_RELEASE=0.Y.Y DOCKER_REPO=mesos
+```
+
+Where 0.X.X and 0.Y.Y are the respective versions of Storm and Mesos you wish to build against.  This will build a docker image containing a Mesos executor package. The resulting docker images are the following:
+
+```
+± docker images
+REPOSITORY                TAG                                    IMAGE ID            CREATED 
+mesos/storm-mesos         0.1.0-0.X.X-0.Y.Y-jdk7                 11989e7bfa17        44 minutes ago
+mesos/storm-mesos         0.1.0-0.X.X-0.Y.Y-jdk7-onbuild         e7eb52b3eb9f        44 minutes ago
+```
+
+In order to use JDK 8 while building the docker image, run the following:
+
+```shell
+make images STORM_RELEASE=0.X.X MESOS_RELEASE=0.Y.Y DOCKER_REPO=mesos JAVA_PRODUCT_VERSION=8
+```
+
+A custom image could be built from the onbuild tagged docker image. It is based on the dockerfile ``onbuild/Dockerfile``
 
 # Running Storm on Mesos
 Along with the Mesos master and Mesos cluster, you'll need to run the Storm master as well. Launch Nimbus with this command:

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -25,6 +25,10 @@ STORM_URL=${STORM_URL:-''}
 
 MIRROR=${MIRROR:-"http://www.gtlib.gatech.edu/pub"}
 
+DOCKER_REPO=${DOCKER_REPO:-"mesos"}
+
+JAVA_PRODUCT_VERSION=${JAVA_PRODUCT_VERSION:-`java -version 2>&1 | awk '/version/{print $NF}' | sed -E 's|[0-9].([0-9]).[0-9]_[0-9]+|\1|' | sed -e 's/^"//'  -e 's/"$//'`}
+
 function help {
   cat <<USAGE
 Usage: bin/build-release.sh [<storm.tar.gz>]
@@ -118,12 +122,14 @@ function package {(
 )}
 
 function dockerImage {(
-  cmd="docker build \
-       --build-arg MESOS_RELEASE=$MESOS_RELEASE \
-       --build-arg STORM_RELEASE=$STORM_RELEASE \
-       --build-arg MIRROR=$MIRROR \
-       --build-arg STORM_URL=$STORM_URL \
-        -t mesos/storm:git-`git rev-parse --short HEAD` ."
+  cmd="make images \
+      STORM_RELEASE=$STORM_RELEASE \
+      MESOS_RELEASE=$MESOS_RELEASE \
+      RELEASE=$RELEASE \
+      MIRROR=$MIRROR \
+      STORM_URL=$STORM_URL \
+      JAVA_PRODUCT_VERSION=$JAVA_PRODUCT_VERSION \
+      DOCKER_REPO=$DOCKER_REPO"
   echo $cmd
   $cmd
 )}

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -5,27 +5,27 @@ FROM ubuntu:14.04
 MAINTAINER Salimane Adjao Moustapha <me@salimane.com>
 
 # set JAVA_HOME depending if JAVA_PRODUCT_VERSION is set
-ARG JAVA_PRODUCT_VERSION=''
-ENV TARGET_JAVA_HOME ${JAVA_PRODUCT_VERSION:+/usr/lib/jvm/java-$JAVA_PRODUCT_VERSION-openjdk-amd64}
-ENV JAVA_HOME ${TARGET_JAVA_HOME:-/usr/lib/jvm/java-7-openjdk-amd64}
-ENV JAVA_PRODUCT_VERSION ${JAVA_PRODUCT_VERSION:-7}
+ONBUILD ARG JAVA_PRODUCT_VERSION=''
+ONBUILD ENV TARGET_JAVA_HOME ${JAVA_PRODUCT_VERSION:+/usr/lib/jvm/java-$JAVA_PRODUCT_VERSION-openjdk-amd64}
+ONBUILD ENV JAVA_HOME ${TARGET_JAVA_HOME:-/usr/lib/jvm/java-7-openjdk-amd64}
+ONBUILD ENV JAVA_PRODUCT_VERSION ${JAVA_PRODUCT_VERSION:-7}
 
 # Add mesosphere
 # install mesos version, build arg, MESOS_RELEASE with a default value
-ARG MESOS_RELEASE=0.28.0
-RUN DISTRO=$(lsb_release -is | tr "[:upper:]" "[:lower:]") && \
+ONBUILD ARG MESOS_RELEASE=0.28.0
+ONBUILD RUN DISTRO=$(lsb_release -is | tr "[:upper:]" "[:lower:]") && \
 	CODENAME=$(lsb_release -cs) && \
 	echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
 	apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
 	apt-get -y update && \
 	apt-get -y install mesos=`apt-cache madison mesos | grep " ${MESOS_RELEASE}" | head -1 | awk '{print $3}'` && \
-	apt-get clean
+	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # set build arg STORM_RELEASE, MIRROR with defaults values
-ARG STORM_RELEASE=0.10.0
-ARG MIRROR=''
-ARG STORM_URL=''
-ARG RELEASE=''
+ONBUILD ARG STORM_RELEASE=0.10.0
+ONBUILD ARG MIRROR=''
+ONBUILD ARG STORM_URL=''
+ONBUILD ARG RELEASE=''
 
 # set runtime environment variables
 ENV MESOS_RELEASE ${MESOS_RELEASE:-0.28.0}
@@ -37,7 +37,7 @@ ENV MESOS_NATIVE_JAVA_LIBRARY ${MESOS_NATIVE_JAVA_LIBRARY:-/usr/lib/libmesos.so}
 COPY . /tmp
 
 # storm-mesos package building if file storm-mesos*.tgz not found
-RUN cd /tmp && \
+ONBUILD RUN cd /tmp && \
 	RELEASE=`grep -1 -A 0 -B 0 '<version>' pom.xml | head -n 1 | awk '{print $1}' | sed -e 's/.*<version>//' | sed -e 's/<\/version>.*//'` && \
 	([ -f storm-mesos-${RELEASE}-storm${STORM_RELEASE}-mesos${MESOS_RELEASE}.tgz ] || \
 		(apt-get -y install software-properties-common && \


### PR DESCRIPTION
This PR makes it possible to automate the building of storm-mesos docker images based on storm, mesos versions.

I've also included in this PR:

- an onbuild version of the storm-mesos docker image to import from if needed
- ability to build a JAVA 8 runtime version of the docker image
- add a makefile for building and pushing docker images
- update the function ``dockerImage`` in ``build_release.sh`` to use the new make target

To build a new storm-mesos docker image, just do:
```shell
make help
make images STORM_RELEASE=0.10.0 MESOS_RELEASE=0.28.0 DOCKER_REPO=mesos
```

This PR needs to be merged before I could finish off #83  #117 with automated docker image building on docker hub

With this PR, we can also close #109 .

cc @erikdw @lfundaro @DarinJ @dsKarthick 
Thanks