### PR TITLE
fix issue with vagrant start-nimbus.sh script

### DIFF
--- a/vagrant/start-nimbus.sh
+++ b/vagrant/start-nimbus.sh
@@ -13,7 +13,10 @@ cd /vagrant/_release/storm-mesos-${RELEASE}-*
 
 # kill existing MesosNimbus and storm UI processes
 kill `ps aux | grep MesosNimbu[s] | awk '{print $2}'` &> /dev/null || /bin/true
+# Grr... the below *was* working, but now the jar paths are too long with the long package version name.
 kill `ps aux | grep backtype.storm.ui.cor[e] | awk '{print $2}'` &> /dev/null || /bin/true
+# So using this more aggressive form now.
+kill `ps aux | grep stor[m] | grep -v grep | awk '{print $2}'` &> /dev/null || /bin/true
 
 # Start storm nimbus, which also acts as the mesos scheduler in this case.
 # Point the STORM_CONF_DIR to where the repo's storm.yaml lives, so we can modify it


### PR DESCRIPTION
After we increased the package version name with all the useful info about
mesos and storm version, the process names are now too long for us to be
able to see the whole command in `ps` output (Linux limits the process length
to 4096 bytes by default).  So we cannot search for the correct daemon name
since it is cut off.  The brutal workaround is to kill all processes with
'storm' in their name.