### PR TITLE
Automate the building of docker images and push them to docker hub on every tag release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: java
-sudo: false
+sudo: required
+dist: trusty
 cache:
   directories:
   - $HOME/.m2/repository
+services:
+  - docker
+env:
+  global:
+    - TRAVIS_DOCKER_VERSION=1.10.3-0~trusty
+    - DOCKER_REPO=mesos
+before_install:
+  - apt-cache madison docker-engine
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${TRAVIS_DOCKER_VERSION}
+
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true
 script:
 - jdk_switcher use oraclejdk8
@@ -17,6 +28,13 @@ matrix:
   - env: STORM_RELEASE="0.10.0" MESOS_RELEASE="0.27.2"
   - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.28.0"
   - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.27.2"
+before_deploy:
+  - make images
+  - make images JAVA_PRODUCT_VERSION=8
+  - docker images
+  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+  - make push
+  - make push JAVA_PRODUCT_VERSION=8
 # Deploy archives to GitHub release tags
 deploy:
   provider: releases


### PR DESCRIPTION
Before merging this, set the environment variables ``DOCKER_EMAIL``, ``DOCKER_USERNAME``, ``DOCKER_PASSWORD``

```
cd storm
travis env set DOCKER_EMAIL <docker email to use>
travis env set DOCKER_USERNAME <docker username to use>
travis env set DOCKER_PASSWORD <docker hub pass to use>
```

With this PR, after tagging a new release, travis will build the docker images and automatically push them to https://hub.docker.com/r/mesos/


Signed-off-by: Salimane Adjao Moustapha <me@salimane.com>