### PR TITLE
Fix Nimbus Crash on Bad Config

### DIFF
--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -134,34 +134,36 @@ public class MesosCommon {
     return ret;
   }
 
+  public static Number getScalarTopologyConf(Map conf, String configName, String topologyName, Number defaultValue) {
+    Object configOption = conf.get(configName);
+
+    Number ret = defaultValue;
+    if (configOption != null && !(configOption instanceof Number)) {
+      LOG.warn("Topology {} has invalid option \'{}\' -- Expected type \'{}\', Actual type \'{}\' -- Falling back to default of {}", topologyName, configName, Number.class, configOption.getClass(), defaultValue);
+    } else if (configOption != null && configOption instanceof Number) {
+      ret = (Number) configOption;
+    } else {
+      LOG.debug("Topology {} does not set {}, default of {} will be used", topologyName, configName, defaultValue);
+    }
+    return ret;
+  }
+
   public static double topologyWorkerCpu(Map conf, TopologyDetails info) {
     Map topologyConfig = getFullTopologyConfig(conf, info);
-    Object cpuObject = topologyConfig.get(WORKER_CPU_CONF);
-    double topologyWorkerCpu = DEFAULT_WORKER_CPU;
-    if (cpuObject != null && !(cpuObject instanceof Number)) {
-      LOG.warn("Topology {} has invalid mesos cpu configuration: {} has type {}, when it should be a Number", info.getId(), cpuObject, cpuObject.getClass());
-    } else if (cpuObject != null && (cpuObject instanceof Number)) {
-      topologyWorkerCpu = ((Number) cpuObject).doubleValue();
-      if (topologyWorkerCpu < MESOS_MIN_CPU) {
-        LOG.warn("Topology {} has invalid mesos cpu configuration: {} is below {} which is the mesos minimum", info.getId(), topologyWorkerCpu, MESOS_MIN_CPU);
-        topologyWorkerCpu = DEFAULT_WORKER_CPU;
-      }
+    double topologyWorkerCpu = getScalarTopologyConf(topologyConfig, WORKER_CPU_CONF, info.getId(), DEFAULT_WORKER_CPU).doubleValue();
+    if (topologyWorkerCpu < MESOS_MIN_CPU) {
+      LOG.warn("Topology {} has invalid option \'{}\' -- {} is below {}, which is the minimum defined by Mesos -- Falling back to default of {}", info.getId(), WORKER_CPU_CONF, topologyWorkerCpu, MESOS_MIN_CPU, DEFAULT_WORKER_CPU);
+      topologyWorkerCpu = DEFAULT_WORKER_CPU;
     }
     return topologyWorkerCpu;
   }
 
   public static double topologyWorkerMem(Map conf, TopologyDetails info) {
     Map topologyConfig = getFullTopologyConfig(conf, info);
-    Object memObject = topologyConfig.get(WORKER_MEM_CONF);
-    double topologyWorkerMem = DEFAULT_WORKER_MEM_MB;
-    if (memObject != null && !(memObject instanceof Number)) {
-      LOG.warn("Topology {} has invalid mesos mem configuration: {} has type {}, when it should be a Number", info.getId(), memObject, memObject.getClass());
-    } else if (memObject != null && (memObject instanceof Number)) {
-      topologyWorkerMem = ((Number) memObject).doubleValue();
-      if (topologyWorkerMem < MESOS_MIN_MEM_MB) {
-        LOG.warn("Topology {} has invalid mesos mem configuration: {} is below {} which is the mesos minimum", info.getId(), topologyWorkerMem, MESOS_MIN_MEM_MB);
-        topologyWorkerMem = DEFAULT_WORKER_MEM_MB;
-      }
+    double topologyWorkerMem = getScalarTopologyConf(topologyConfig, WORKER_MEM_CONF, info.getId(), DEFAULT_WORKER_MEM_MB).doubleValue();
+    if (topologyWorkerMem < MESOS_MIN_MEM_MB) {
+      LOG.warn("Topology {} has invalid option \'{}\' -- {} is below {}, which is the minimum defined by Mesos -- Falling back to default of {}", info.getId(), WORKER_MEM_CONF, topologyWorkerMem, MESOS_MIN_MEM_MB, DEFAULT_WORKER_MEM_MB);
+      topologyWorkerMem = DEFAULT_WORKER_MEM_MB;
     }
     return topologyWorkerMem;
   }

--- a/storm/src/test/storm/mesos/MesosCommonTest.java
+++ b/storm/src/test/storm/mesos/MesosCommonTest.java
@@ -34,6 +34,8 @@ public class MesosCommonTest {
   private Map conf;
   private TopologyDetails info;
   private String topologyName = "t_name";
+  private static final double DELTA = 0.0001;
+
 
   @Before
   public void initConf() {
@@ -201,7 +203,7 @@ public class MesosCommonTest {
     // Test default value
     double result = MesosCommon.topologyWorkerCpu(conf, info);
     double expectedResult = MesosCommon.DEFAULT_WORKER_CPU;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
 
     // Test what happens when config is too small
     double cpuConfig = MesosCommon.MESOS_MIN_CPU;
@@ -209,14 +211,20 @@ public class MesosCommonTest {
     conf.put(MesosCommon.WORKER_CPU_CONF, cpuConfig);
     result = MesosCommon.topologyWorkerCpu(conf, info);
     expectedResult = MesosCommon.DEFAULT_WORKER_CPU;
-    assertEquals(result, expectedResult, 0.0001);
+    assertEquals(result, expectedResult, DELTA);
+
+    // Test what happens when config is null
+    conf.put(MesosCommon.WORKER_CPU_CONF, null);
+    result = MesosCommon.topologyWorkerCpu(conf, info);
+    expectedResult = MesosCommon.DEFAULT_WORKER_CPU;
+    assertEquals(result, expectedResult, DELTA);
 
     // Test explicit value
     conf.put(MesosCommon.WORKER_CPU_CONF, 1.5);
     info = new TopologyDetails("t2", conf, new StormTopology(), 2);
     result = MesosCommon.topologyWorkerCpu(conf, info);
     expectedResult = 1.5;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
 
     // Test string passed in
     conf = new HashMap<>();
@@ -224,7 +232,7 @@ public class MesosCommonTest {
     info = new TopologyDetails("t3", conf, new StormTopology(), 1);
     result = MesosCommon.topologyWorkerCpu(conf, info);
     expectedResult = 1;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
 
     // Test that this value is not overwritten by Topology config
     Map nimbusConf = new HashMap<>();
@@ -234,7 +242,7 @@ public class MesosCommonTest {
     info = new TopologyDetails("t4", conf, new StormTopology(), 1);
     result = MesosCommon.topologyWorkerCpu(nimbusConf, info);
     expectedResult = 1.5;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
   }
 
   @Test
@@ -242,7 +250,7 @@ public class MesosCommonTest {
     // Test default value
     double result = MesosCommon.topologyWorkerMem(conf, info);
     double expectedResult = MesosCommon.DEFAULT_WORKER_MEM_MB;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
     
     // Test what happens when config is too small
     double memConfig = MesosCommon.MESOS_MIN_MEM_MB;
@@ -250,21 +258,27 @@ public class MesosCommonTest {
     conf.put(MesosCommon.WORKER_MEM_CONF, memConfig);
     result = MesosCommon.topologyWorkerMem(conf, info);
     expectedResult = MesosCommon.DEFAULT_WORKER_MEM_MB;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
+
+    // Test what happens when config is null
+    conf.put(MesosCommon.WORKER_MEM_CONF, null);
+    result = MesosCommon.topologyWorkerMem(conf, info);
+    expectedResult = MesosCommon.DEFAULT_WORKER_MEM_MB;
+    assertEquals(result, expectedResult, DELTA);
 
     // Test explicit value
     conf.put(MesosCommon.WORKER_MEM_CONF, 1200);
     info = new TopologyDetails("t2", conf, new StormTopology(), 2);
     result = MesosCommon.topologyWorkerMem(conf, info);
     expectedResult = 1200;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
 
     // Test string passed in
     conf.put(MesosCommon.WORKER_MEM_CONF, "1200");
     info = new TopologyDetails("t3", conf, new StormTopology(), 1);
     result = MesosCommon.topologyWorkerMem(conf, info);
     expectedResult = 1000;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
 
     // Test that this value is overwritten by Topology config
     Map nimbusConf = new HashMap<>();
@@ -273,7 +287,7 @@ public class MesosCommonTest {
     info = new TopologyDetails("t4", conf, new StormTopology(), 1);
     result = MesosCommon.topologyWorkerMem(nimbusConf, info);
     expectedResult = 150;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
   }
 
   @Test
@@ -281,13 +295,13 @@ public class MesosCommonTest {
     // Test default config
     double result = MesosCommon.executorCpu(conf);
     double expectedResult = MesosCommon.DEFAULT_EXECUTOR_CPU;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
 
     // Test explicit value
     conf.put(MesosCommon.EXECUTOR_CPU_CONF, 2.0);
     result = MesosCommon.executorCpu(conf);
     expectedResult = 2.0;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
   }
 
   @Test
@@ -295,12 +309,12 @@ public class MesosCommonTest {
     // Test default config
     double result = MesosCommon.executorMem(conf);
     double expectedResult = MesosCommon.DEFAULT_EXECUTOR_MEM_MB;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
 
     // Test explicit value
     conf.put(MesosCommon.EXECUTOR_MEM_CONF, 100);
     result = MesosCommon.executorMem(conf);
     expectedResult = 100;
-    assertEquals(result, expectedResult, 0.001);
+    assertEquals(result, expectedResult, DELTA);
   }
 }

--- a/storm/src/test/storm/mesos/MesosCommonTest.java
+++ b/storm/src/test/storm/mesos/MesosCommonTest.java
@@ -1,0 +1,306 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package storm.mesos;
+
+import backtype.storm.generated.StormTopology;
+import backtype.storm.scheduler.TopologyDetails;
+import org.junit.Before;
+import org.junit.Test;
+import storm.mesos.util.MesosCommon;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MesosCommonTest {
+
+  private Map conf;
+  private TopologyDetails info;
+  private String topologyName = "t_name";
+
+  @Before
+  public void initConf() {
+      conf = new HashMap<>();
+      conf.put("topology.name", topologyName);
+      info = new TopologyDetails("t1", conf, new StormTopology(), 1);
+  }
+
+  @Test
+  public void testHostFromAssignmentId() throws Exception {
+    String assignmentId = "a-test-assignment-id-host";
+    String delimiter = "-";
+
+    String result = MesosCommon.hostFromAssignmentId(assignmentId, delimiter);
+    String expectedResult = "host";
+
+    assertEquals(result, expectedResult);
+  }
+
+  @Test
+  public void testGetWorkerPrefix() throws Exception {
+
+    // Test default values
+    String result = MesosCommon.getWorkerPrefix(conf, info);
+    String expectedResult = topologyName + MesosCommon.DEFAULT_WORKER_NAME_PREFIX_DELIMITER;
+    assertEquals(result, expectedResult);
+
+    // Test explicit value of prefix
+    String prefix = ":(";
+    conf.put(MesosCommon.WORKER_NAME_PREFIX, prefix);
+    info = new TopologyDetails("t2", conf, new StormTopology(), 1);
+    result = MesosCommon.getWorkerPrefix(conf, info);
+    expectedResult = prefix + topologyName + MesosCommon.DEFAULT_WORKER_NAME_PREFIX_DELIMITER;
+    assertEquals(result, expectedResult);
+    conf.remove(MesosCommon.WORKER_NAME_PREFIX);
+
+    // Test explicit value of delimiter
+    String delimiter = ":)";
+    conf.put(MesosCommon.WORKER_NAME_PREFIX_DELIMITER, delimiter);
+    info = new TopologyDetails("t3", conf, new StormTopology(), 1);
+    result = MesosCommon.getWorkerPrefix(conf, info);
+    expectedResult = topologyName + delimiter;
+    assertEquals(result, expectedResult);
+
+    // Test explicit value of prefix and delimiter
+    conf.put(MesosCommon.WORKER_NAME_PREFIX, prefix);
+    info = new TopologyDetails("t4", conf, new StormTopology(), 2);
+    result = MesosCommon.getWorkerPrefix(conf, info);
+    expectedResult = prefix + topologyName + delimiter;
+    assertEquals(result, expectedResult);
+  }
+
+  @Test
+  public void testGetMesosComponentNameDelimiter() throws Exception {
+    String topologyName = "t_name";
+
+    // Test default values
+    String result = MesosCommon.getMesosComponentNameDelimiter(conf, info);
+    String expectedResult = MesosCommon.DEFAULT_MESOS_COMPONENT_NAME_DELIMITER;
+    assertEquals(result, expectedResult);
+
+    // Test explicit value
+    info = new TopologyDetails("t2", conf, new StormTopology(), 2);
+    String delimiter = "-";
+    conf.put(MesosCommon.MESOS_COMPONENT_NAME_DELIMITER, delimiter);
+    result = MesosCommon.getMesosComponentNameDelimiter(conf, info);
+    expectedResult = delimiter;
+    assertEquals(result, expectedResult);
+
+    // Test explicit value
+    info = new TopologyDetails("t2", conf, new StormTopology(), 2);
+    conf = new HashMap<>();
+    result = MesosCommon.getMesosComponentNameDelimiter(conf, info);
+    expectedResult = delimiter;
+    assertEquals(result, expectedResult);
+
+    // Test explicit value overridden in topology config
+    conf = new HashMap<>();
+    conf.put(MesosCommon.MESOS_COMPONENT_NAME_DELIMITER, delimiter);
+    info = new TopologyDetails("t3", conf, new StormTopology(), 3);
+    Map nimbusConf = new HashMap<>();
+    nimbusConf.put(MesosCommon.MESOS_COMPONENT_NAME_DELIMITER, "--");
+    result = MesosCommon.getMesosComponentNameDelimiter(nimbusConf, info);
+    expectedResult = delimiter;
+    assertEquals(result, expectedResult);
+  }
+
+  @Test
+  public void testTaskId() throws Exception {
+    String nodeid = "nodeID1";
+    int port = 52;
+    // Regex format for timestamp is %d.%03d
+    String result = MesosCommon.taskId(nodeid, port);
+    String[] expectedElements = result.split("-");
+    // The taskId should be in at least three parts
+    assertTrue(3 >= expectedElements.length);
+    assertEquals(nodeid, expectedElements[0]);
+    String portAsString = "" + port + "";
+    assertEquals(portAsString, expectedElements[1]);
+    // The last part is timestamp number, ignore for now, will be different every time
+  }
+
+  @Test
+  public void testSupervisorId() throws Exception {
+    String nodeid = "nodeID1";
+    String topologyid = "t1";
+    String result = MesosCommon.supervisorId(nodeid, topologyid);
+    String expectedResult = nodeid + "-" + topologyid;
+    assertEquals(result, expectedResult);
+  }
+
+  @Test
+  public void testStartLogViewer() throws Exception {
+    // Test the default (true)
+    boolean result = MesosCommon.startLogViewer(conf);
+    assertTrue(result);
+    conf.put(MesosCommon.AUTO_START_LOGVIEWER_CONF, false);
+    result = MesosCommon.startLogViewer(conf);
+    assertTrue(!result);
+  }
+
+  @Test
+  public void testPortFromTaskId() throws Exception {
+    String taskid = "nodeid-22-time.stamp";
+    int result = MesosCommon.portFromTaskId(taskid);
+    int expectedResult = 22;
+
+    assertEquals(result, expectedResult);
+  }
+
+  @Test
+  public void testGetSuicideTimeout() throws Exception {
+    // Test default value
+    int result = MesosCommon.getSuicideTimeout(conf);
+    int expectedResult = MesosCommon.DEFAULT_SUICIDE_TIMEOUT_SECS;
+    assertEquals(result, expectedResult);
+
+    // Test explicit value
+    conf.put(MesosCommon.SUICIDE_CONF, 12);
+    result = MesosCommon.getSuicideTimeout(conf);
+    expectedResult = 12;
+    assertEquals(result, expectedResult);
+  }
+
+  @Test
+  public void testGetFullTopologyConfig() throws Exception {
+    Map nimbusConf = new HashMap<>();
+    nimbusConf.put("TEST_NIMBUS_CONFIG", 1);
+    nimbusConf.put("TEST_TOPOLOGY_OVERRIDE", 2);
+    Map topologyConf = new HashMap<>();
+    topologyConf.put("TEST_TOPOLIGY_CONFIG", 3);
+    topologyConf.put("TEST_TOPOLOGY_OVERRIDE", 4);
+    TopologyDetails info = new TopologyDetails("t1", topologyConf, new StormTopology(), 2);
+    Map result = MesosCommon.getFullTopologyConfig(nimbusConf, info);
+    Map expectedResult = new HashMap<>();
+    expectedResult.put("TEST_NIMBUS_CONFIG", 1);
+    expectedResult.put("TEST_TOPOLIGY_CONFIG", 3);
+    expectedResult.put("TEST_TOPOLOGY_OVERRIDE", 4);
+
+    assertEquals(result, expectedResult);
+  }
+
+  @Test
+  public void testTopologyWorkerCpu() throws Exception {
+    // Test default value
+    double result = MesosCommon.topologyWorkerCpu(conf, info);
+    double expectedResult = MesosCommon.DEFAULT_WORKER_CPU;
+    assertEquals(result, expectedResult, 0.001);
+
+    // Test what happens when config is too small
+    double cpuConfig = MesosCommon.MESOS_MIN_CPU;
+    cpuConfig -= 0.001;
+    conf.put(MesosCommon.WORKER_CPU_CONF, cpuConfig);
+    result = MesosCommon.topologyWorkerCpu(conf, info);
+    expectedResult = MesosCommon.DEFAULT_WORKER_CPU;
+    assertEquals(result, expectedResult, 0.0001);
+
+    // Test explicit value
+    conf.put(MesosCommon.WORKER_CPU_CONF, 1.5);
+    info = new TopologyDetails("t2", conf, new StormTopology(), 2);
+    result = MesosCommon.topologyWorkerCpu(conf, info);
+    expectedResult = 1.5;
+    assertEquals(result, expectedResult, 0.001);
+
+    // Test string passed in
+    conf = new HashMap<>();
+    conf.put(MesosCommon.WORKER_CPU_CONF, "2");
+    info = new TopologyDetails("t3", conf, new StormTopology(), 1);
+    result = MesosCommon.topologyWorkerCpu(conf, info);
+    expectedResult = 1;
+    assertEquals(result, expectedResult, 0.001);
+
+    // Test that this value is not overwritten by Topology config
+    Map nimbusConf = new HashMap<>();
+    nimbusConf.put(MesosCommon.WORKER_CPU_CONF, 2);
+    conf = new HashMap<>();
+    conf.put(MesosCommon.WORKER_CPU_CONF, 1.5);
+    info = new TopologyDetails("t4", conf, new StormTopology(), 1);
+    result = MesosCommon.topologyWorkerCpu(nimbusConf, info);
+    expectedResult = 1.5;
+    assertEquals(result, expectedResult, 0.001);
+  }
+
+  @Test
+  public void testTopologyWorkerMem() throws Exception {
+    // Test default value
+    double result = MesosCommon.topologyWorkerMem(conf, info);
+    double expectedResult = MesosCommon.DEFAULT_WORKER_MEM_MB;
+    assertEquals(result, expectedResult, 0.001);
+    
+    // Test what happens when config is too small
+    double memConfig = MesosCommon.MESOS_MIN_MEM_MB;
+    memConfig -= 1.0;
+    conf.put(MesosCommon.WORKER_MEM_CONF, memConfig);
+    result = MesosCommon.topologyWorkerMem(conf, info);
+    expectedResult = MesosCommon.DEFAULT_WORKER_MEM_MB;
+    assertEquals(result, expectedResult, 0.001);
+
+    // Test explicit value
+    conf.put(MesosCommon.WORKER_MEM_CONF, 1200);
+    info = new TopologyDetails("t2", conf, new StormTopology(), 2);
+    result = MesosCommon.topologyWorkerMem(conf, info);
+    expectedResult = 1200;
+    assertEquals(result, expectedResult, 0.001);
+
+    // Test string passed in
+    conf.put(MesosCommon.WORKER_MEM_CONF, "1200");
+    info = new TopologyDetails("t3", conf, new StormTopology(), 1);
+    result = MesosCommon.topologyWorkerMem(conf, info);
+    expectedResult = 1000;
+    assertEquals(result, expectedResult, 0.001);
+
+    // Test that this value is overwritten by Topology config
+    Map nimbusConf = new HashMap<>();
+    nimbusConf.put(MesosCommon.WORKER_MEM_CONF, 200);
+    conf.put(MesosCommon.WORKER_MEM_CONF, 150);
+    info = new TopologyDetails("t4", conf, new StormTopology(), 1);
+    result = MesosCommon.topologyWorkerMem(nimbusConf, info);
+    expectedResult = 150;
+    assertEquals(result, expectedResult, 0.001);
+  }
+
+  @Test
+  public void testExecutorCpu() throws Exception {
+    // Test default config
+    double result = MesosCommon.executorCpu(conf);
+    double expectedResult = MesosCommon.DEFAULT_EXECUTOR_CPU;
+    assertEquals(result, expectedResult, 0.001);
+
+    // Test explicit value
+    conf.put(MesosCommon.EXECUTOR_CPU_CONF, 2.0);
+    result = MesosCommon.executorCpu(conf);
+    expectedResult = 2.0;
+    assertEquals(result, expectedResult, 0.001);
+  }
+
+  @Test
+  public void testExecutorMem() throws Exception {
+    // Test default config
+    double result = MesosCommon.executorMem(conf);
+    double expectedResult = MesosCommon.DEFAULT_EXECUTOR_MEM_MB;
+    assertEquals(result, expectedResult, 0.001);
+
+    // Test explicit value
+    conf.put(MesosCommon.EXECUTOR_MEM_CONF, 100);
+    result = MesosCommon.executorMem(conf);
+    expectedResult = 100;
+    assertEquals(result, expectedResult, 0.001);
+  }
+}


### PR DESCRIPTION
This pull request fixes an issue where if a user submitted a topology with `topology.mesos.cpu` or `topology.mesos.mem.mb` set to an incorrect type, the Nimbus will crash. Because of this, even when run under supervision the topology with the bad config is still living in ZK and continually kills the Nimbus.

To fix this, we now make the following changes:
1. Check to see if `topology.mesos.cpu` and `topology.mesos.mem.mb` are of type Number. If they are not, reset them to the default.
2. While we're at it, we should also check to see if `topology.mesos.cpu` and `topology.mesos.mem.mb` are too low for Mesos, if they are, reset them to the default.
3. Add tests so that these changes (and most of the other functionality of MesosCommon) are being verified on build so that this cannot happen again.