### PR TITLE
support building storm-mesos with patched storm packages

### DIFF
--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -59,7 +59,7 @@ USAGE
 }; function --help { help ;}; function -h { help ;}
 
 function downloadStormRelease {
-  if [ ! -f apache-storm-${STORM_RELEASE}.tar.gz ]; then
+  if [ ! -f apache-storm-${STORM_RELEASE}*.tar.gz ]; then
     if [ -z ${STORM_URL} ]; then
       curl -L -O ${MIRROR}/apache/storm/apache-storm-${STORM_RELEASE}/apache-storm-${STORM_RELEASE}.tar.gz
     else
@@ -108,7 +108,7 @@ function package {(
   local tarName="${dirName}.tgz"
   cd _release
   # When supervisor starts up it looks for storm-mesos not apache-storm.
-  mv apache-storm-${STORM_RELEASE} ${dirName}
+  mv apache-storm-${STORM_RELEASE}* ${dirName}
   tar cvzf ${tarName} --numeric-owner --owner 0 --group 0 ${dirName}
   echo "Copying ${tarName} to $(cd .. && pwd)/${tarName}"
   cp ${tarName} ../
@@ -153,7 +153,7 @@ function main {
   clean
   downloadStormRelease
   mvnPackage
-  prePackage apache-storm-${STORM_RELEASE}.tar.gz
+  prePackage apache-storm-${STORM_RELEASE}*.tar.gz
   package
 }
 


### PR DESCRIPTION
This allows use of an alternate storm package via STORM_URL which could have
a suffix.  e.g.,

```
apache-storm-0.9.6-storm-mesos3.tar.gz
```

instead of what the format would have to be prior to this fix:

```
apache-storm-0.9.6.tar.gz
```

Example incantations of bin/build-release.sh with alternate storm packages:

```
STORM_URL=file:///tmp/apache-storm-0.9.6-storm-mesos3.tar.gz STORM_RELEASE=0.9.6 MESOS_RELEASE=0.27.1 bin/build-release.sh

STORM_URL=https://github.com/erikdw/storm/releases/download/v0.9.6-storm-mesos3/apache-storm-0.9.6-storm-mesos3.tar.gz STORM_RELEASE=0.9.6 MESOS_RELEASE=0.27.1 bin/build-release.sh
```