### PR TITLE
update storm to 0.10.1 and mesos to 0.28.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ script:
 matrix:
   fast_finish: true
   include:
-  - env: STORM_RELEASE="0.10.0" MESOS_RELEASE="0.28.0"
-  - env: STORM_RELEASE="0.10.0" MESOS_RELEASE="0.27.2"
-  - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.28.0"
+  - env: STORM_RELEASE="0.10.1" MESOS_RELEASE="0.28.1"
+  - env: STORM_RELEASE="0.10.1" MESOS_RELEASE="0.27.2"
+  - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.28.1"
   - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.27.2"
 before_deploy:
   - make images

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ script:
 matrix:
   fast_finish: true
   include:
-  - env: STORM_RELEASE="0.10.1" MESOS_RELEASE="0.28.1"
+  - env: STORM_RELEASE="0.10.1" MESOS_RELEASE="0.28.2"
   - env: STORM_RELEASE="0.10.1" MESOS_RELEASE="0.27.2"
-  - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.28.1"
+  - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.28.2"
   - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.27.2"
 before_deploy:
   - make images

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_PRODUCT_VERSION ${JAVA_PRODUCT_VERSION:-7}
 
 # Add mesosphere
 # install mesos version, build arg, MESOS_RELEASE with a default value
-ARG MESOS_RELEASE=0.28.1
+ARG MESOS_RELEASE=0.28.2
 RUN DISTRO=$(lsb_release -is | tr "[:upper:]" "[:lower:]") && \
         CODENAME=$(lsb_release -cs) && \
         echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
@@ -28,7 +28,7 @@ ARG STORM_URL=''
 ARG RELEASE=''
 
 # set runtime environment variables
-ENV MESOS_RELEASE ${MESOS_RELEASE:-0.28.1}
+ENV MESOS_RELEASE ${MESOS_RELEASE:-0.28.2}
 ENV STORM_RELEASE ${STORM_RELEASE:-0.10.1}
 ENV DEBIAN_FRONTEND ${DEBIAN_FRONTEND:-noninteractive}
 ENV MESOS_NATIVE_JAVA_LIBRARY ${MESOS_NATIVE_JAVA_LIBRARY:-/usr/lib/libmesos.so}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV JAVA_PRODUCT_VERSION ${JAVA_PRODUCT_VERSION:-7}
 
 # Add mesosphere
 # install mesos version, build arg, MESOS_RELEASE with a default value
-ARG MESOS_RELEASE=0.28.0
+ARG MESOS_RELEASE=0.28.1
 RUN DISTRO=$(lsb_release -is | tr "[:upper:]" "[:lower:]") && \
         CODENAME=$(lsb_release -cs) && \
         echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
@@ -22,14 +22,14 @@ RUN DISTRO=$(lsb_release -is | tr "[:upper:]" "[:lower:]") && \
         apt-get clean
 
 # set build arg STORM_RELEASE, MIRROR with defaults values
-ARG STORM_RELEASE=0.10.0
+ARG STORM_RELEASE=0.10.1
 ARG MIRROR=''
 ARG STORM_URL=''
 ARG RELEASE=''
 
 # set runtime environment variables
-ENV MESOS_RELEASE ${MESOS_RELEASE:-0.28.0}
-ENV STORM_RELEASE ${STORM_RELEASE:-0.10.0}
+ENV MESOS_RELEASE ${MESOS_RELEASE:-0.28.1}
+ENV STORM_RELEASE ${STORM_RELEASE:-0.10.1}
 ENV DEBIAN_FRONTEND ${DEBIAN_FRONTEND:-noninteractive}
 ENV MESOS_NATIVE_JAVA_LIBRARY ${MESOS_NATIVE_JAVA_LIBRARY:-/usr/lib/libmesos.so}
 

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ all: help
 
 help:
 	@echo 'Options available:'
-	@echo '  make images STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.1 DOCKER_REPO=mesos'
-	@echo '  make push   STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.1 DOCKER_REPO=mesos'
+	@echo '  make images STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.2 DOCKER_REPO=mesos'
+	@echo '  make push   STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.2 DOCKER_REPO=mesos'
 	@echo ''
 	@echo 'ENV'
 	@echo '  STORM_RELEASE          The targeted release version of Storm'
 	@echo '                             Default: 0.10.1'
 	@echo '  MESOS_RELEASE          The targeted release version of MESOS'
-	@echo '                             Default: 0.28.1'
+	@echo '                             Default: 0.28.2'
 	@echo '  DOCKER_REPO            The docker repo for which to build the docker image'
 	@echo '                             Default: mesos'
 	@echo '  RELEASE                The targeted release version of Storm'

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ all: help
 
 help:
 	@echo 'Options available:'
-	@echo '  make images STORM_RELEASE=0.10.0 MESOS_RELEASE=0.28.0 DOCKER_REPO=mesos'
-	@echo '  make push   STORM_RELEASE=0.10.0 MESOS_RELEASE=0.28.0 DOCKER_REPO=mesos'
+	@echo '  make images STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.1 DOCKER_REPO=mesos'
+	@echo '  make push   STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.1 DOCKER_REPO=mesos'
 	@echo ''
 	@echo 'ENV'
 	@echo '  STORM_RELEASE          The targeted release version of Storm'
-	@echo '                             Default: 0.10.0'
+	@echo '                             Default: 0.10.1'
 	@echo '  MESOS_RELEASE          The targeted release version of MESOS'
-	@echo '                             Default: 0.28.0'
+	@echo '                             Default: 0.28.1'
 	@echo '  DOCKER_REPO            The docker repo for which to build the docker image'
 	@echo '                             Default: mesos'
 	@echo '  RELEASE                The targeted release version of Storm'

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -12,7 +12,7 @@ ONBUILD ENV JAVA_PRODUCT_VERSION ${JAVA_PRODUCT_VERSION:-7}
 
 # Add mesosphere
 # install mesos version, build arg, MESOS_RELEASE with a default value
-ONBUILD ARG MESOS_RELEASE=0.28.1
+ONBUILD ARG MESOS_RELEASE=0.28.2
 ONBUILD RUN DISTRO=$(lsb_release -is | tr "[:upper:]" "[:lower:]") && \
         CODENAME=$(lsb_release -cs) && \
         echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
@@ -28,7 +28,7 @@ ONBUILD ARG STORM_URL=''
 ONBUILD ARG RELEASE=''
 
 # set runtime environment variables
-ENV MESOS_RELEASE ${MESOS_RELEASE:-0.28.1}
+ENV MESOS_RELEASE ${MESOS_RELEASE:-0.28.2}
 ENV STORM_RELEASE ${STORM_RELEASE:-0.10.1}
 ENV DEBIAN_FRONTEND ${DEBIAN_FRONTEND:-noninteractive}
 ENV MESOS_NATIVE_JAVA_LIBRARY ${MESOS_NATIVE_JAVA_LIBRARY:-/usr/lib/libmesos.so}

--- a/onbuild/Dockerfile
+++ b/onbuild/Dockerfile
@@ -12,7 +12,7 @@ ONBUILD ENV JAVA_PRODUCT_VERSION ${JAVA_PRODUCT_VERSION:-7}
 
 # Add mesosphere
 # install mesos version, build arg, MESOS_RELEASE with a default value
-ONBUILD ARG MESOS_RELEASE=0.28.0
+ONBUILD ARG MESOS_RELEASE=0.28.1
 ONBUILD RUN DISTRO=$(lsb_release -is | tr "[:upper:]" "[:lower:]") && \
         CODENAME=$(lsb_release -cs) && \
         echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" > /etc/apt/sources.list.d/mesosphere.list && \
@@ -22,14 +22,14 @@ ONBUILD RUN DISTRO=$(lsb_release -is | tr "[:upper:]" "[:lower:]") && \
         apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # set build arg STORM_RELEASE, MIRROR with defaults values
-ONBUILD ARG STORM_RELEASE=0.10.0
+ONBUILD ARG STORM_RELEASE=0.10.1
 ONBUILD ARG MIRROR=''
 ONBUILD ARG STORM_URL=''
 ONBUILD ARG RELEASE=''
 
 # set runtime environment variables
-ENV MESOS_RELEASE ${MESOS_RELEASE:-0.28.0}
-ENV STORM_RELEASE ${STORM_RELEASE:-0.10.0}
+ENV MESOS_RELEASE ${MESOS_RELEASE:-0.28.1}
+ENV STORM_RELEASE ${STORM_RELEASE:-0.10.1}
 ENV DEBIAN_FRONTEND ${DEBIAN_FRONTEND:-noninteractive}
 ENV MESOS_NATIVE_JAVA_LIBRARY ${MESOS_NATIVE_JAVA_LIBRARY:-/usr/lib/libmesos.so}
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <profile>
       <id>storm10</id>
       <properties>
-        <storm.version>0.10.0</storm.version>
+        <storm.version>0.10.1</storm.version>
         <shim>storm-shim-10x</shim>
         <snakeyaml.scope>compile</snakeyaml.scope>
       </properties>

--- a/storm-shim-10x/pom.xml
+++ b/storm-shim-10x/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.storm</groupId>
       <artifactId>storm-core</artifactId>
-      <version>0.10.0</version>
+      <version>0.10.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Updating from storm-0.10.0 to storm-0.10.1 fixes issue #140, which references
the inability to change the Storm Thrift port in Storm version 0.10.0:
* https://issues.apache.org/jira/browse/STORM-1645

Also update from mesos-0.28.0 to mesos-0.28.1 since it has been released.