### PR TITLE
update the DOCKER_REPO variable to be the full repo path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 env:
   global:
     - TRAVIS_DOCKER_VERSION=1.10.3-0~trusty
-    - DOCKER_REPO=mesos
+    - DOCKER_REPO=mesos/storm
 before_install:
   - apt-cache madison docker-engine
   - travis_retry sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${TRAVIS_DOCKER_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 #
 RELEASE ?= `grep -1 -A 0 -B 0 '<version>' pom.xml | head -n 1 | awk '{print $1}' | sed -e 's/.*<version>//' | sed -e 's/<\/version>.*//'`
-DOCKER_REPO ?= mesos
+DOCKER_REPO ?= mesos/storm
 MIRROR ?=
 STORM_URL ?=
 JAVA_PRODUCT_VERSION ?= 7
@@ -14,8 +14,8 @@ all: help
 
 help:
 	@echo 'Options available:'
-	@echo '  make images STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.2 DOCKER_REPO=mesos'
-	@echo '  make push   STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.2 DOCKER_REPO=mesos'
+	@echo '  make images STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.2 DOCKER_REPO=mesos/storm'
+	@echo '  make push   STORM_RELEASE=0.10.1 MESOS_RELEASE=0.28.2 DOCKER_REPO=mesos/storm'
 	@echo ''
 	@echo 'ENV'
 	@echo '  STORM_RELEASE          The targeted release version of Storm'
@@ -23,7 +23,7 @@ help:
 	@echo '  MESOS_RELEASE          The targeted release version of MESOS'
 	@echo '                             Default: 0.28.2'
 	@echo '  DOCKER_REPO            The docker repo for which to build the docker image'
-	@echo '                             Default: mesos'
+	@echo '                             Default: mesos/storm'
 	@echo '  RELEASE                The targeted release version of Storm'
 	@echo '                             Default: current version in pom.xml'
 	@echo '  JAVA_PRODUCT_VERSION   The java product version to use in the docker image'
@@ -54,12 +54,12 @@ images: check-version
        	--build-arg JAVA_PRODUCT_VERSION=$(JAVA_PRODUCT_VERSION) \
        	--build-arg MIRROR=$(MIRROR) \
        	--build-arg STORM_URL=$(STORM_URL) \
-		-t $(DOCKER_REPO)/storm:$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION) .
+		-t $(DOCKER_REPO):$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION) .
 	docker build \
 		--rm \
 		-f onbuild/Dockerfile \
-		-t $(DOCKER_REPO)/storm:$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION)-onbuild .
+		-t $(DOCKER_REPO):$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION)-onbuild .
 
 push: check-version
-	docker push $(DOCKER_REPO)/storm:$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION)
-	docker push $(DOCKER_REPO)/storm:$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION)-onbuild
+	docker push $(DOCKER_REPO):$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION)
+	docker push $(DOCKER_REPO):$(RELEASE)-$(STORM_RELEASE)-$(MESOS_RELEASE)-jdk$(JAVA_PRODUCT_VERSION)-onbuild

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In order to build the storm-mesos docker image, or a docker image ready to be us
 
 ```shell
 make help
-make images STORM_RELEASE=0.X.X MESOS_RELEASE=0.Y.Y DOCKER_REPO=mesos
+make images STORM_RELEASE=0.X.X MESOS_RELEASE=0.Y.Y DOCKER_REPO=mesos/storm
 ```
 
 Where 0.X.X and 0.Y.Y are the respective versions of Storm and Mesos you wish to build against.  This will build a docker image containing a Mesos executor package. The resulting docker images are the following:
@@ -84,7 +84,7 @@ mesos/storm               0.1.0-0.X.X-0.Y.Y-jdk7-onbuild         e7eb52b3eb9f   
 In order to use JDK 8 while building the docker image, run the following:
 
 ```shell
-make images STORM_RELEASE=0.X.X MESOS_RELEASE=0.Y.Y DOCKER_REPO=mesos JAVA_PRODUCT_VERSION=8
+make images STORM_RELEASE=0.X.X MESOS_RELEASE=0.Y.Y DOCKER_REPO=mesos/storm JAVA_PRODUCT_VERSION=8
 ```
 
 A custom image could be built from the onbuild tagged docker image. It is based on the dockerfile ``onbuild/Dockerfile``

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -25,7 +25,7 @@ STORM_URL=${STORM_URL:-''}
 
 MIRROR=${MIRROR:-"http://www.gtlib.gatech.edu/pub"}
 
-DOCKER_REPO=${DOCKER_REPO:-"mesos"}
+DOCKER_REPO=${DOCKER_REPO:-"mesos/storm"}
 
 JAVA_PRODUCT_VERSION=${JAVA_PRODUCT_VERSION:-`java -version 2>&1 | awk '/version/{print $NF}' | sed -E 's|[0-9].([0-9]).[0-9]_[0-9]+|\1|' | sed -e 's/^"//'  -e 's/"$//'`}
 


### PR DESCRIPTION
This change avoids the assumption that the target docker repo will be `foo/storm`,
where only the `foo` portion is controlled by `DOCKER_REPO`.
With this fix it could be `foo/storm-mesos` for example.

The current `DOCKER_REPO` variable isn't referring to the full repo "slug", instead
it just references the user/organization portion of the slug, and assumes the project
name will always be `storm`.  That is not necessarily the case, for example in my fork
of `mesos/storm` I call the project `erikdw/storm-mesos` instead of just `erikdw/storm`.
That is done to avoid a conflict with the actual storm project (`apache/storm`), which
I also have forked under my name (`erikdw/storm`).