### PR TITLE
use $TRAVIS_REPO_SLUG instead of hardcoded repo slug of mesos/storm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 env:
   global:
     - TRAVIS_DOCKER_VERSION=1.10.3-0~trusty
-    - DOCKER_REPO=mesos/storm
+    - DOCKER_REPO=$TRAVIS_REPO_SLUG
 before_install:
   - apt-cache madison docker-engine
   - travis_retry sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${TRAVIS_DOCKER_VERSION}
@@ -44,4 +44,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    repo: mesos/storm
+    repo: $TRAVIS_REPO_SLUG


### PR DESCRIPTION
Remove hardcoded GitHub & DockerHub repo slugs for deploy, in favor of
the `$TRAVIS_REPO_SLUG` environment variable.

The advantage of is that we can do testing of build-related changes in
child forks of `mesos/storm` without having to carefully update
`deploy.on.repo` & `DOCKER_REPO` to our own personal repos.
Similarly we won't have to maintain such changes in our child forks
(e.g., by doing `git stash save` and then `git stash pop` when we are
working in that child repo).

Tested this behavior already in my own fork of `mesos/storm` (`erikdw/storm-mesos`):
* https://travis-ci.org/erikdw/storm-mesos/builds/138315660

Files got uploaded to the expected locations:
* https://github.com/erikdw/storm-mesos/releases
* https://hub.docker.com/r/erikdw/storm-mesos/tags