### PR TITLE
use erikdw/storm's patched version of storm 0.9.6 to build storm-mesos package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ matrix:
   include:
   - env: STORM_RELEASE="0.10.1" MESOS_RELEASE="0.28.2"
   - env: STORM_RELEASE="0.10.1" MESOS_RELEASE="0.27.2"
-  - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.28.2"
-  - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.27.2"
+  - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.28.2" STORM_URL="https://github.com/erikdw/storm/releases/download/v0.9.6-storm-mesos2/apache-storm-0.9.6-storm-mesos2.tar.gz"
+  - env: STORM_RELEASE="0.9.6" MESOS_RELEASE="0.27.2" STORM_URL="https://github.com/erikdw/storm/releases/download/v0.9.6-storm-mesos2/apache-storm-0.9.6-storm-mesos2.tar.gz"
 before_deploy:
   - travis_retry make images
   - travis_retry make images JAVA_PRODUCT_VERSION=8


### PR DESCRIPTION
Per the [release notes in erikdw/storm](https://github.com/erikdw/storm/releases) there are
a few tweaks that have been made to storm to make it more friendly for running storm-mesos:

1. Per-topology worker logs
2. Shorten java classpaths in various commands to ensure ps output includes full command
3. Flush bin/storm output output before exec'ing java process