### PR TITLE
improve handling of status updates

### DIFF
--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -300,7 +300,7 @@ public class MesosNimbus implements INimbus {
     }
   }
 
-  public void taskLost(final TaskID taskId) {
+  public void taskTerminated(final TaskID taskId) {
     timerScheduler.schedule(new Runnable() {
       @Override
       public void run() {

--- a/storm/src/main/storm/mesos/NimbusScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusScheduler.java
@@ -88,16 +88,24 @@ public class NimbusScheduler implements Scheduler {
 
   @Override
   public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
-    LOG.debug("Received status update: {}", taskStatusToString(status));
     switch (status.getState()) {
+      case TASK_STAGING:
+      case TASK_STARTING:
+        LOG.debug("Received status update: {}", taskStatusToString(status));
+        break;
+      case TASK_RUNNING:
+        LOG.info("Received status update: {}", taskStatusToString(status));
+        break;
       case TASK_FINISHED:
       case TASK_FAILED:
       case TASK_KILLED:
       case TASK_LOST:
-        final TaskID taskId = status.getTaskId();
-        mesosNimbus.taskLost(taskId);
+      case TASK_ERROR:
+        LOG.info("Received status update: {}", taskStatusToString(status));
+        mesosNimbus.taskTerminated(status.getTaskId());
         break;
       default:
+        LOG.warn("Received unrecognized status update: {}", taskStatusToString(status));
         break;
     }
   }


### PR DESCRIPTION
1. For unrecognized status types we were falling into the default case and doing nothing.
  That was really bad with the introduction of TASK_ERROR for situations where the
  ExecutorInfo was mismatched between tasks for a topology, since the update/error wasn't
  appearing in the nimbus logs, only in the mesos-master logs.
  So now we log such updates at warning level.
2. Also just be more explicit about printing out the status updates for the normal flow,
  by logging at info level for TASK_RUNNING and the terminal states.
3. Also rename the `taskLost` method to `taskTerminated`, since it is not just for the
  lost statuses that we perform the action.