### PR TITLE
bin/storm-mesos launcher script: use exec to replace process instead of spawning separate child process

### DIFF
--- a/bin/storm-mesos
+++ b/bin/storm-mesos
@@ -11,7 +11,7 @@ STORM_CMD = STORM_PATH + "/storm"
 def nimbus(*args):
     os.chdir(STORM_PATH + "/..")
     args = [STORM_CMD, "nimbus", "storm.mesos.MesosNimbus"] + list(args)
-    sys.exit(subprocess.call(args))
+    os.execv(STORM_CMD, args)
 
 COMMANDS = {"nimbus": nimbus}
 


### PR DESCRIPTION
Mimic the behavior of storm's `bin/storm` launcher by using `exec`-style of replacing
the current process with the child.

This is useful when using a system like runit to supervise the daemons, since otherwise
there are 2 separate processes (the python launcher & the java process) and runit only
kills the 1st one.