### PR TITLE
development releases now include the source as a tarball

### DIFF
--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -95,10 +95,14 @@ function package {(
 
   # for development builds, create a tarball of the source and copy into the package
   if [[ "${RELEASE}" == *"SNAPSHOT"* ]]; then
-    local stashRef=`git stash create`
-    local srcTarballDir=storm-mesos-src-${stashRef}
+    local stashRef=$(git stash create)
+    local archiveRef=${stashRef}
+    if [ -z ${stashRef} ]; then
+      archiveRef=HEAD
+    fi
+    local srcTarballDir=storm-mesos-src-${archiveRef}
     local srcTarball=${srcTarballDir}.tgz
-    git archive --format=tar.gz -o ${srcTarball} --prefix ${srcTarballDir}/ ${stashRef}
+    git archive --format=tar.gz -o ${srcTarball} --prefix ${srcTarballDir}/ ${archiveRef}
     echo "Copying ${srcTarball} to $stormDir/."
     cp ${srcTarball} $stormDir/.
   fi

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -93,6 +93,16 @@ function package {(
   local stormDir=`find _release -maxdepth 1 -type d -name "*storm*"`
   _rm $stormDir/*.jar
 
+  # for development builds, create a tarball of the source and copy into the package
+  if [[ "${RELEASE}" == *"SNAPSHOT"* ]]; then
+    local stashRef=`git stash create`
+    local srcTarballDir=storm-mesos-src-${stashRef}
+    local srcTarball=${srcTarballDir}.tgz
+    git archive --format=tar.gz -o ${srcTarball} --prefix ${srcTarballDir}/ ${stashRef}
+    echo "Copying ${srcTarball} to $stormDir/."
+    cp ${srcTarball} $stormDir/.
+  fi
+
   # copies storm-mesos jar over
   # We only want the shaded jar. Its important to remove the original
   # jar so we dont have both shaded as well as original jar in the classpath


### PR DESCRIPTION
This fixes [issue #163](https://github.com/mesos/storm/issues/163).