### PR TITLE
Change LocalFileServer to allow respecting storm.yaml's nimbus.host

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ services:
 - docker
 env:
   global:
-  - TRAVIS_DOCKER_VERSION=1.10.3-0~trusty
   - DOCKER_REPO=$TRAVIS_REPO_SLUG
 before_install:
 - apt-cache madison docker-engine
-- travis_retry sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${TRAVIS_DOCKER_VERSION}
+- travis_retry sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true
 script:
 - jdk_switcher use oraclejdk8

--- a/storm/src/main/storm/mesos/LocalFileServer.java
+++ b/storm/src/main/storm/mesos/LocalFileServer.java
@@ -43,7 +43,7 @@ public class LocalFileServer {
 
   public static void main(String[] args) throws Exception {
 
-    URI url = new LocalFileServer().serveDir("/tmp2", "/tmp", Optional.<Integer>absent());
+    URI url = new LocalFileServer().serveDir("/tmp2", "/tmp", getHost(), Optional.<Integer>absent());
     System.out.println("************ " + url);
 
   }
@@ -57,7 +57,7 @@ public class LocalFileServer {
    * @return Full URI including server, port and path of baselevel dir. Please note that the ancient Jetty 6.1 Storm uses can't be configured to return directory listings AFAIK.
    * @throws Exception
    */
-  public URI serveDir(String uriPath, String filePath, Optional<Integer> port) throws Exception {
+  public URI serveDir(String uriPath, String filePath, String host, Optional<Integer> port) throws Exception {
 
     if (port.isPresent()) {
       LOG.info("Starting local file server on port: {}", port.get());
@@ -81,12 +81,12 @@ public class LocalFileServer {
     _server.setHandler(handlers);
     _server.start();
 
-    // get the connector once it is init so we can get the actual host & port it bound to.
+    // get the connector once it is init so we can get the actual port it bound to.
     Connector initConn = _server.getConnectors()[0];
-    return new URI("http", null, getHost(), initConn.getLocalPort(), uriPath, null, null);
+    return new URI("http", null, host, initConn.getLocalPort(), uriPath, null, null);
   }
 
-  private String getHost() throws Exception {
+  private static String getHost() throws Exception {
     return Optional.fromNullable((String) System.getenv("MESOS_NIMBUS_HOST"))
         .or(InetAddress.getLocalHost().getCanonicalHostName());
   }

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -344,7 +344,7 @@ public class MesosNimbus implements INimbus {
 
   private void setupHttpServer() throws Exception {
     _httpServer = new LocalFileServer();
-    _configUrl = _httpServer.serveDir("/generated-conf", _generatedConfPath.toString(), _localFileServerPort);
+    _configUrl = _httpServer.serveDir("/generated-conf", _generatedConfPath.toString(), MesosCommon.getNimbusHost(mesosStormConf), _localFileServerPort);
 
     LOG.info("Started HTTP server from which config for the MesosSupervisor's may be fetched. URL: {}", _configUrl);
   }


### PR DESCRIPTION
Prior to this the only way to configure the URL that LocalFileServer listens
to is via MESOS_NIMBUS_HOST environment variable.  That differs from the
behavior of the core MesosNimbus which supports that env variable, as well
as the nimbus.host field in the storm.yaml config.  So update the code to
make them equally configurable.