### PR TITLE
Removed unused LRU taskIDtoOfferMap and related code

### DIFF
--- a/storm/src/main/storm/mesos/NimbusScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusScheduler.java
@@ -88,21 +88,21 @@ public class NimbusScheduler implements Scheduler {
 
   @Override
   public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
+    String msg = String.format("Received status update: %s", taskStatusToString(status));
     switch (status.getState()) {
       case TASK_STAGING:
       case TASK_STARTING:
-        LOG.debug("Received status update: {}", taskStatusToString(status));
+        LOG.debug(msg);
         break;
       case TASK_RUNNING:
-        LOG.info("Received status update: {}", taskStatusToString(status));
+        LOG.info(msg);
         break;
       case TASK_FINISHED:
       case TASK_FAILED:
       case TASK_KILLED:
       case TASK_LOST:
       case TASK_ERROR:
-        LOG.info("Received status update: {}", taskStatusToString(status));
-        mesosNimbus.taskTerminated(status.getTaskId());
+        LOG.info(msg);
         break;
       default:
         LOG.warn("Received unrecognized status update: {}", taskStatusToString(status));


### PR DESCRIPTION
@erikdw @JessicaLHartog 

Using the following steps to run example storm topologies on vagrant setup for testing the changes:

1. `sudo sh -c 'echo "192.168.50.101 master" >> /etc/hosts'`
` sudo sh -c 'echo "192.168.50.102 slave"  >> /etc/hosts' `

2. Update storm.yaml
```
mesos.master.url: "zk://master:2181/mesos"
storm.zookeeper.servers:
- "master"
mesos.executor.uri: "file:///usr/local/storm/storm-mesos-0.1.8-SNAPSHOT-storm0.9.6-mesos0.27.0.tgz"
```
3. Run `bin/build-release.sh`
4. Run `mvn clean package` from local machine's storm starter folder (`_release/storm-mesos*/examples/storm-starter`)
5. Run `vagrant up`, then `vagrant provision` if asked for
6. Check UI at `master:8080` and manually run `sudo /vagrant/vagrant/start-nimbus.sh` from vagrant master.
7. Run the following commands from the target folder at vagrant master (`/vagrant/_release/storm-mesos*/examples/storm-starter/target`)
```
/vagrant/_release/storm-mesos-0.1.8-SNAPSHOT-storm0.9.6-mesos0.27.0/bin/storm jar storm-starter-0.9.6-jar-with-dependencies.jar storm.starter.ExclamationTopology ExclamationTopology
/vagrant/_release/storm-mesos-0.1.8-SNAPSHOT-storm0.9.6-mesos0.27.0/bin/storm jar storm-starter-0.9.6-jar-with-dependencies.jar storm.starter.WordCountTopology WordCountTopology
```
After executing the steps above I am able to see the topologies running and emitting tuples.