### PR TITLE
Added suppressOffers for framework if its nimbus is not leader

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,11 @@ For local development and familiarizing yourself with Storm/Mesos, please see th
 * `mesos.disallowed.hosts`: Disallowed hosts to run topology, which takes hostname list as a back list.
 * `mesos.framework.role`: Framework role to use. Defaults to "*".
 * `mesos.framework.checkpoint`: Enabled framework checkpoint or not. Defaults to false.
-* `mesos.offer.lru.cache.size`: LRU cache size. Defaults to "1000".
 * `mesos.offer.filter.seconds`: Number of seconds to filter unused Mesos offers. These offers may be revived by
   the framework when needed. Defaults to "120".
 * `mesos.offer.expiry.multiplier`: Offer expiry multiplier for `nimbus.monitor.freq.secs`. Defaults to "2.5".
+* `mesos.nimbus.leader.check.delay.secs`: Nimbus leader check task delay in seconds. Defaults to "120".
+* `mesos.nimbus.leader.check.period.secs`: Nimbus leader check task period in seconds. Defaults to "60".
 * `mesos.local.file.server.port`: Port for the local file server to bind to. Defaults to a random port.
 * `mesos.framework.name`: Framework name. Defaults to "Storm!!!".
 * `mesos.framework.principal`: Framework principal to use to register with Mesos


### PR DESCRIPTION
@erikdw 

We want to run 3 HA nimbus instances. Mesos will see them as 3 frameworks.

Mesos master generates offers to all registered frameworks using Dominant Resource Fairness algorithm.
Offers are held by storm-mesos framework even if nimbus is not leader and this can cause resource starvation in cluster, because remaining offers will be held by other (non leader) storm frameworks.

The solution is to suppressOffers for non leader frameworks and reviveOffers only for framework with nimbus leader. If new nimbus leader will be elected,  this task would reviveOffers for new leader.

There are 2 new configuration settings:

* `mesos.nimbus.leader.check.delay.secs`: Nimbus leader check task delay in seconds. Defaults to "120". If this setting is set to 0 - all frameworks will be suppressed at first and will reviveOffers after  `mesos.nimbus.leader.check.period.secs`. You might want to set this setting to bigger value if all active  frameworks should accept offers at first and only suppress offers after this delay.
* `mesos.nimbus.leader.check.period.secs`: Nimbus leader check task period in seconds. Defaults to "60".

I also removed adding Config.NIMBUS_HOST to config because it was deprecated in storm 1.0.0