### PR TITLE
Change deprecated `nimbus.host`-> `nimbus.seeds`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ to Nimbus, you'll need to know the Thrift host and API port. In the Marathon exa
 one assigned by Marathon. For example, if the host is `10.0.0.1` and second port is `32001`, run:
 
 ```
-$ ./bin/storm jar -c nimbus.host=10.0.0.1 -c nimbus.thrift.port=32001 examples/storm-starter/storm-starter-topologies-0.9.6.jar storm.starter.WordCountTopology word-count
+$ ./bin/storm jar -c nimbus.seeds=[10.0.0.1] -c nimbus.thrift.port=32001 examples/storm-starter/storm-starter-topologies-0.9.6.jar storm.starter.WordCountTopology word-count
 ```
 
 ## Running without Marathon


### PR DESCRIPTION
A change introduced in v1.0.0 of apache storm. Using `nimbus.host` will still work but will produces the following error:
`Using deprecated config nimbus.host for backward compatibility. Please update your storm.yaml so it only has config nimbus.seeds`
https://issues.apache.org/jira/browse/STORM-1185