### PR TITLE
Exclude examples dir from release packages

### DIFF
--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -126,7 +126,7 @@ function package {(
   cd _release
   # When supervisor starts up it looks for storm-mesos not apache-storm.
   mv apache-storm-${STORM_RELEASE}* ${dirName}
-  tar cvzf ${tarName} --numeric-owner --owner 0 --group 0 ${dirName}
+  tar cvzf ${tarName} --numeric-owner --owner 0 --group 0 --exclude ${dirName}/examples ${dirName}
   echo "Copying ${tarName} to $(cd .. && pwd)/${tarName}"
   cp ${tarName} ../
 


### PR DESCRIPTION
I could reduced the capacity of release packages from 177MB to 114MB by excluding `examples/` directory from release packages.

See #178 for details.

Please check this pull request.

Thanks.