### PR TITLE
Renamed a few classes for clarity: DefaultScheduler and NimbusScheduler

### DIFF
--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -125,7 +125,7 @@ public class MesosNimbus implements INimbus {
   private Optional<Integer> _localFileServerPort;
   private RotatingMap<OfferID, Offer> _offers;
   private LocalFileServer _httpServer;
-  private IMesosStormScheduler _mesosStormScheduler = null;
+  private IMesosStormScheduler _stormScheduler = null;
 
   private boolean _preferReservedResources = true;
   private Optional<String> _container = Optional.absent();
@@ -140,7 +140,7 @@ public class MesosNimbus implements INimbus {
   }
 
   public MesosNimbus() {
-    this._mesosStormScheduler = new StormSchedulerImpl();
+    this._stormScheduler = new StormSchedulerImpl();
   }
 
   public static void main(String[] args) {
@@ -159,7 +159,7 @@ public class MesosNimbus implements INimbus {
   @Override
   public IScheduler getForcedScheduler() {
     // TODO: Make it configurable. We should be able to specify the scheduler to use in the storm.yaml
-    return (IScheduler) _mesosStormScheduler;
+    return (IScheduler) _stormScheduler;
   }
 
   @Override
@@ -350,7 +350,7 @@ public class MesosNimbus implements INimbus {
   public Collection<WorkerSlot> allSlotsAvailableForScheduling(
           Collection<SupervisorDetails> existingSupervisors, Topologies topologies, Set<String> topologiesMissingAssignments) {
     synchronized (_offersLock) {
-      return _mesosStormScheduler.allSlotsAvailableForScheduling(
+      return _stormScheduler.allSlotsAvailableForScheduling(
               _offers,
               existingSupervisors,
               topologies,

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -116,7 +116,7 @@ public class MesosNimbus implements INimbus {
   private final Object _offersLock = new Object();
   protected java.net.URI _configUrl;
   private LocalStateShim _state;
-  private NimbusMesosScheduler _scheduler;
+  private NimbusMesosScheduler _mesosScheduler;
   volatile SchedulerDriver _driver;
   private Timer _timer = new Timer();
   private Map mesosStormConf;
@@ -179,7 +179,7 @@ public class MesosNimbus implements INimbus {
 
       LOG.info("Waiting for scheduler driver to register MesosNimbus with mesos-master and complete initialization...");
 
-      _scheduler.waitUntilRegistered();
+      _mesosScheduler.waitUntilRegistered();
 
       LOG.info("Scheduler registration and initialization complete...");
 
@@ -208,7 +208,7 @@ public class MesosNimbus implements INimbus {
     }
 
     _container = Optional.fromNullable((String) conf.get(CONF_MESOS_CONTAINER_DOCKER_IMAGE));
-    _scheduler = new NimbusMesosScheduler(this);
+    _mesosScheduler = new NimbusMesosScheduler(this);
 
     // Generate YAML to be served up to clients
     _generatedConfPath = Paths.get(
@@ -330,9 +330,9 @@ public class MesosNimbus implements INimbus {
     LOG.info(String.format("Registering framework with role '%s'", finfo.getRole()));
 
     if ((credential = getCredential(finfo)) != null) {
-      driver = new MesosSchedulerDriver(_scheduler, finfo.build(), (String) mesosStormConf.get(CONF_MASTER_URL), credential);
+      driver = new MesosSchedulerDriver(_mesosScheduler, finfo.build(), (String) mesosStormConf.get(CONF_MASTER_URL), credential);
     } else {
-      driver = new MesosSchedulerDriver(_scheduler, finfo.build(), (String) mesosStormConf.get(CONF_MASTER_URL));
+      driver = new MesosSchedulerDriver(_mesosScheduler, finfo.build(), (String) mesosStormConf.get(CONF_MASTER_URL));
     }
 
     return driver;

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -57,7 +57,7 @@ import storm.mesos.resources.ResourceEntries.ScalarResourceEntry;
 import storm.mesos.resources.ResourceEntry;
 import storm.mesos.resources.ResourceNotAvailableException;
 import storm.mesos.resources.ResourceType;
-import storm.mesos.schedulers.DefaultScheduler;
+import storm.mesos.schedulers.StormSchedulerImpl;
 import storm.mesos.schedulers.IMesosStormScheduler;
 import storm.mesos.shims.CommandLineShimFactory;
 import storm.mesos.shims.ICommandLineShim;
@@ -116,7 +116,7 @@ public class MesosNimbus implements INimbus {
   private final Object _offersLock = new Object();
   protected java.net.URI _configUrl;
   private LocalStateShim _state;
-  private NimbusScheduler _scheduler;
+  private NimbusMesosScheduler _scheduler;
   volatile SchedulerDriver _driver;
   private Timer _timer = new Timer();
   private Map mesosStormConf;
@@ -140,7 +140,7 @@ public class MesosNimbus implements INimbus {
   }
 
   public MesosNimbus() {
-    this._mesosStormScheduler = new DefaultScheduler();
+    this._mesosStormScheduler = new StormSchedulerImpl();
   }
 
   public static void main(String[] args) {
@@ -208,7 +208,7 @@ public class MesosNimbus implements INimbus {
     }
 
     _container = Optional.fromNullable((String) conf.get(CONF_MESOS_CONTAINER_DOCKER_IMAGE));
-    _scheduler = new NimbusScheduler(this);
+    _scheduler = new NimbusMesosScheduler(this);
 
     // Generate YAML to be served up to clients
     _generatedConfPath = Paths.get(

--- a/storm/src/main/storm/mesos/NimbusMesosScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusMesosScheduler.java
@@ -34,12 +34,12 @@ import java.util.concurrent.CountDownLatch;
 
 import static storm.mesos.util.PrettyProtobuf.taskStatusToString;
 
-public class NimbusScheduler implements Scheduler {
+public class NimbusMesosScheduler implements Scheduler {
   private MesosNimbus mesosNimbus;
   private CountDownLatch _registeredLatch = new CountDownLatch(1);
   public static final Logger LOG = LoggerFactory.getLogger(MesosNimbus.class);
 
-  public NimbusScheduler(MesosNimbus mesosNimbus) {
+  public NimbusMesosScheduler(MesosNimbus mesosNimbus) {
     this.mesosNimbus = mesosNimbus;
   }
 

--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -48,8 +48,8 @@ import java.util.Set;
 /**
  *  Default Scheduler used by mesos-storm framework.
  */
-public class DefaultScheduler implements IScheduler, IMesosStormScheduler {
-  private final Logger log = LoggerFactory.getLogger(DefaultScheduler.class);
+public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
+  private final Logger log = LoggerFactory.getLogger(StormSchedulerImpl.class);
   private Map mesosStormConf;
   private final Map<String, MesosWorkerSlot> mesosWorkerSlotMap = new HashMap<>();
 

--- a/storm/src/test/storm/mesos/schedulers/StormSchedulerImplTest.java
+++ b/storm/src/test/storm/mesos/schedulers/StormSchedulerImplTest.java
@@ -54,10 +54,10 @@ import static storm.mesos.TestUtils.buildOffer;
 import static storm.mesos.TestUtils.buildOfferWithPorts;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DefaultSchedulerTest {
+public class StormSchedulerImplTest {
 
   @Spy
-  private DefaultScheduler defaultScheduler;
+  private StormSchedulerImpl stormSchedulerImpl;
   private Map<String, MesosWorkerSlot> mesosWorkerSlotMap;
 
   private Topologies topologies;
@@ -82,7 +82,7 @@ public class DefaultSchedulerTest {
   }
 
   private void initializeMesosWorkerSlotMap(List<MesosWorkerSlot> mesosWorkerSlots) {
-    mesosWorkerSlotMap = (HashMap<String, MesosWorkerSlot>) (Whitebox.getInternalState(defaultScheduler, "mesosWorkerSlotMap"));
+    mesosWorkerSlotMap = (HashMap<String, MesosWorkerSlot>) (Whitebox.getInternalState(stormSchedulerImpl, "mesosWorkerSlotMap"));
     for (MesosWorkerSlot mesosWorkerSlot: mesosWorkerSlots) {
       mesosWorkerSlotMap.put(String.format("%s:%s", mesosWorkerSlot.getNodeId(), mesosWorkerSlot.getPort()), mesosWorkerSlot);
     }
@@ -145,9 +145,9 @@ public class DefaultSchedulerTest {
 
   @Before
   public void initialize() {
-    defaultScheduler = new DefaultScheduler();
+    stormSchedulerImpl = new StormSchedulerImpl();
     Map<String, Object> mesosStormConf = new HashMap<>();
-    defaultScheduler.prepare(mesosStormConf);
+    stormSchedulerImpl.prepare(mesosStormConf);
 
     rotatingMap = new RotatingMap<>(2);
 
@@ -173,21 +173,21 @@ public class DefaultSchedulerTest {
     /* Offer with no ports but enough memory and cpu*/
     Offer offer = buildOffer("offer1", sampleHost, 10, 20000);
     rotatingMap.put(offer.getId(), offer);
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies, topologiesMissingAssignments);
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies, topologiesMissingAssignments);
     assertEquals(workerSlotsAvailableForScheduling.size(), 0);
 
 
     /* Offer with no cpu but enough ports and cpu */
     offer = buildOfferWithPorts("offer1", sampleHost, 0.0, 1000, samplePort, samplePort + 1);
     rotatingMap.put(offer.getId(), offer);
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies, topologiesMissingAssignments);
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies, topologiesMissingAssignments);
     assertEquals(workerSlotsAvailableForScheduling.size(),0);
 
 
     /* Offer with no memory but enough ports and cpu */
     offer = buildOfferWithPorts("offer1", sampleHost, 0.0, 1000, samplePort, samplePort + 1);
     rotatingMap.put(offer.getId(), offer);
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies, topologiesMissingAssignments);
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies, topologiesMissingAssignments);
     assertEquals(workerSlotsAvailableForScheduling.size(),0);
 
 
@@ -196,7 +196,7 @@ public class DefaultSchedulerTest {
     /* XXX(erikdw): Intentionally disabled until we fix https://github.com/mesos/storm/issues/160
     offer = buildOfferWithPorts("offer1", sampleHost, 0.1, 200, samplePort, samplePort + 1);
     rotatingMap.put(offer.getId(), offer);
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies,
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies,
                                                                                         topologiesMissingAssignments);
     assertEquals(1, workerSlotsAvailableForScheduling.size());
     */
@@ -204,7 +204,7 @@ public class DefaultSchedulerTest {
     /* Case 2 - Supervisor does not exists for topology test-topology1-65-1442255385 on the host */
     offer = buildOfferWithPorts("offer1", "host-without-supervisor.example.org", 0.1, 200, samplePort, samplePort + 1);
     rotatingMap.put(offer.getId(), offer);
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies,
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies,
                                                                                         topologiesMissingAssignments);
     assertEquals(0, workerSlotsAvailableForScheduling.size());
 
@@ -212,7 +212,7 @@ public class DefaultSchedulerTest {
     offer = buildOfferWithPorts("offer1", "host-without-supervisor.example.org", 0.1 + MesosCommon.DEFAULT_EXECUTOR_CPU, 200 + MesosCommon.DEFAULT_EXECUTOR_MEM_MB,
                                 3100, 3101);
     rotatingMap.put(offer.getId(), offer);
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies,
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, topologies,
                                                                                         topologiesMissingAssignments);
     assertEquals(1, workerSlotsAvailableForScheduling.size());
 
@@ -222,8 +222,8 @@ public class DefaultSchedulerTest {
     rotatingMap.put(offer.getId(), offer);
     TopologyDetails topologyDetails = TestUtils.constructTopologyDetails(sampleTopologyId, 1);
     topologyMap.put(sampleTopologyId, topologyDetails);
-    defaultScheduler.prepare(topologyDetails.getConf());
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
+    stormSchedulerImpl.prepare(topologyDetails.getConf());
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
                                                                                         topologiesMissingAssignments);
     assertEquals(1, workerSlotsAvailableForScheduling.size());
 
@@ -234,8 +234,8 @@ public class DefaultSchedulerTest {
     rotatingMap.put(offer.getId(), offer);
     topologyDetails = TestUtils.constructTopologyDetails(sampleTopologyId, 10);
     topologyMap.put(sampleTopologyId, topologyDetails);
-    defaultScheduler.prepare(topologyDetails.getConf());
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
+    stormSchedulerImpl.prepare(topologyDetails.getConf());
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
                                                                                         topologiesMissingAssignments);
     assertEquals(2, workerSlotsAvailableForScheduling.size());
 
@@ -245,8 +245,8 @@ public class DefaultSchedulerTest {
     rotatingMap.put(offer.getId(), offer);
     topologyDetails = TestUtils.constructTopologyDetails(sampleTopologyId, 10);
     topologyMap.put(sampleTopologyId, topologyDetails);
-    defaultScheduler.prepare(topologyDetails.getConf());
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
+    stormSchedulerImpl.prepare(topologyDetails.getConf());
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
                                                                                         topologiesMissingAssignments);
     assertEquals(2, workerSlotsAvailableForScheduling.size());
 
@@ -256,8 +256,8 @@ public class DefaultSchedulerTest {
     rotatingMap.put(offer.getId(), offer);
     topologyDetails = TestUtils.constructTopologyDetails(sampleTopologyId, 10);
     topologyMap.put(sampleTopologyId, topologyDetails);
-    defaultScheduler.prepare(topologyDetails.getConf());
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
+    stormSchedulerImpl.prepare(topologyDetails.getConf());
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
                                                                                         topologiesMissingAssignments);
     assertEquals(2, workerSlotsAvailableForScheduling.size());
 
@@ -267,8 +267,8 @@ public class DefaultSchedulerTest {
     rotatingMap.put(offer.getId(), offer);
     topologyDetails = TestUtils.constructTopologyDetails(sampleTopologyId, 10);
     topologyMap.put(sampleTopologyId, topologyDetails);
-    defaultScheduler.prepare(topologyDetails.getConf());
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
+    stormSchedulerImpl.prepare(topologyDetails.getConf());
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
                                                                                         topologiesMissingAssignments);
     assertEquals(10, workerSlotsAvailableForScheduling.size());
   }
@@ -320,9 +320,9 @@ public class DefaultSchedulerTest {
      *  storm/src/test/storm/mesos/MesosNimbusTest.java:    assertEquals(TestUtils.calculateAllAvailableScalarResources(aggregatedOffersPerNode.get("h1"), ResourceType.MEM), 100f, 0.01f);
      *  storm/src/test/storm/mesos/MesosNimbusTest.java:    offer = TestUtils.buildOffer("O-H1-2", "h1", 3.21, 0);
      *  storm/src/test/storm/mesos/MesosNimbusTest.java:    offer = TestUtils.buildOffer("O-H2-2", "h2", 3.21, 0);
-     *  storm/src/test/storm/mesos/schedulers/DefaultSchedulerTest.java:     * all of this project's tests that have y.x1 (e.g., 0.01, 0.91, etc.).
-     *  storm/src/test/storm/mesos/schedulers/DefaultSchedulerTest.java:    offers.add(buildOffer("offer9", sampleHost, 0.01, 0));
-     *  storm/src/test/storm/mesos/schedulers/DefaultSchedulerTest.java:    offers.add(buildOffer("offer12", sampleHost2, 0.01, 10));
+     *  storm/src/test/storm/mesos/schedulers/StormSchedulerImplTest.java:     * all of this project's tests that have y.x1 (e.g., 0.01, 0.91, etc.).
+     *  storm/src/test/storm/mesos/schedulers/StormSchedulerImplTest.java:    offers.add(buildOffer("offer9", sampleHost, 0.01, 0));
+     *  storm/src/test/storm/mesos/schedulers/StormSchedulerImplTest.java:    offers.add(buildOffer("offer12", sampleHost2, 0.01, 10));
      */
     offers.add(buildOffer("offer9", sampleHost, 0.01, 0));
     offers.add(buildOffer("offer12", sampleHost2, 0.01, 10));
@@ -334,9 +334,9 @@ public class DefaultSchedulerTest {
     topologyMap.clear();
     topologyDetails = TestUtils.constructTopologyDetails(sampleTopologyId, 10);
     topologyMap.put(sampleTopologyId, topologyDetails);
-    defaultScheduler.prepare(topologyDetails.getConf());
+    stormSchedulerImpl.prepare(topologyDetails.getConf());
 
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
                                                                                         topologiesMissingAssignments);
     assertEquals(5, workerSlotsAvailableForScheduling.size());
 
@@ -348,9 +348,9 @@ public class DefaultSchedulerTest {
     topologyMap.clear();
     topologyDetails = TestUtils.constructTopologyDetails(sampleTopologyId, 10);
     topologyMap.put(sampleTopologyId, topologyDetails);
-    defaultScheduler.prepare(topologyDetails.getConf());
+    stormSchedulerImpl.prepare(topologyDetails.getConf());
 
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
                                                                                         topologiesMissingAssignments);
     assertEquals(workerSlotsAvailableForScheduling.size(), 3);
 
@@ -360,7 +360,7 @@ public class DefaultSchedulerTest {
     offer = buildOffer("offer7", sampleHost, 3 * DEFAULT_WORKER_CPU, 0);
     rotatingMap.put(offer.getId(), offer);
 
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors,
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors,
                                                                                         new Topologies(topologyMap), topologiesMissingAssignments);
     assertEquals(workerSlotsAvailableForScheduling.size(), 4);
 
@@ -372,7 +372,7 @@ public class DefaultSchedulerTest {
     offer = buildOffer("offer8", sampleHost, 0, 2 * DEFAULT_WORKER_MEM);
     rotatingMap.put(offer.getId(), offer);
 
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors,
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors,
                                                                                         new Topologies(topologyMap), topologiesMissingAssignments);
     assertEquals(workerSlotsAvailableForScheduling.size(), 3);
 
@@ -387,7 +387,7 @@ public class DefaultSchedulerTest {
     offers.add(buildOfferWithPorts("offer9", sampleHost2, 0, 0, samplePort, samplePort + 10));
     addToRotatingMap(offers);
 
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors,
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors,
                                                                                         new Topologies(topologyMap), topologiesMissingAssignments);
     assertEquals(workerSlotsAvailableForScheduling.size(), 10);
   }
@@ -405,7 +405,7 @@ public class DefaultSchedulerTest {
     topologyMap.clear();
     topologyDetails = TestUtils.constructTopologyDetails(sampleTopologyId, 10);
     topologyMap.put(sampleTopologyId, topologyDetails);
-    defaultScheduler.prepare(topologyDetails.getConf());
+    stormSchedulerImpl.prepare(topologyDetails.getConf());
 
     /* 10 worker slots are available but offers are fragmented on one host */
     List<Offer> offers = new ArrayList<>();
@@ -417,7 +417,7 @@ public class DefaultSchedulerTest {
 
 
     // Make sure that the obtained worker slots are evenly spread across the available resources
-    workerSlotsAvailableForScheduling = defaultScheduler.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
+    workerSlotsAvailableForScheduling = stormSchedulerImpl.allSlotsAvailableForScheduling(rotatingMap, existingSupervisors, new Topologies(topologyMap),
                                                                                         topologiesMissingAssignments);
 
     Integer[] expectedWorkerCountPerHost = {3, 3, 1, 3};
@@ -445,7 +445,7 @@ public class DefaultSchedulerTest {
     doReturn(workerSlotList).when(spyCluster).getAvailableSlots();
     doReturn(executorsToAssign).when(spyCluster).getUnassignedExecutors(any(TopologyDetails.class));
 
-    defaultScheduler.schedule(topologies, spyCluster);
+    stormSchedulerImpl.schedule(topologies, spyCluster);
 
     Set<ExecutorDetails> assignedExecutors = spyCluster.getAssignmentById(sampleTopologyId).getExecutors();
     assertEquals(executorsToAssign, assignedExecutors);
@@ -454,7 +454,7 @@ public class DefaultSchedulerTest {
   @Test
   public void testScheduleWithMultipleSlotsOnSameHost() {
     Cluster spyCluster = this.getSpyCluster(3, 3);
-    defaultScheduler.schedule(topologies, spyCluster);
+    stormSchedulerImpl.schedule(topologies, spyCluster);
     SchedulerAssignment schedulerAssignment = spyCluster.getAssignments()
                                                          .get(sampleTopologyId);
     Map<ExecutorDetails, WorkerSlot> executorDetailsWorkerSlotMap = schedulerAssignment.getExecutorToSlot();
@@ -464,7 +464,7 @@ public class DefaultSchedulerTest {
     assertEquals(executorDetailsWorkerSlotMap.values().size(), 3);
 
     spyCluster = this.getSpyCluster(3, 6);
-    defaultScheduler.schedule(topologies, spyCluster);
+    stormSchedulerImpl.schedule(topologies, spyCluster);
     executorDetailsWorkerSlotMap = spyCluster.getAssignments()
                                               .get(sampleTopologyId)
                                               .getExecutorToSlot();


### PR DESCRIPTION
* `DefaultScheduler` was renamed to `StormSchedulerImpl` since this class is a Scheduler Implementation that mimics Storm's default scheduling behavior
   * Also renamed `DefaultSchedulerTest` to reflect these changes
* `NimbusScheduler` was renamed to `NimbusMesosScheduler` since it does not actually schedule things on behalf of Nimbus but acts as an intermediary between Nimbus and Mesos