### PR TITLE
Fixing non-obvious log line

### DIFF
--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -91,8 +91,13 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
         boolean supervisorExists = nodesWithExistingSupervisors.contains(currentNode);
 
         if (!aggregatedOffers.isFit(mesosStormConf, topologyDetails, supervisorExists)) {
-          log.info("{} with requestedWorkerCpu {} and requestedWorkerMem {} does not fit onto {} with resources {}",
-                   topologyDetails.getId(), requestedWorkerCpu, requestedWorkerMemInt, aggregatedOffers.getHostname(), aggregatedOffers.toString());
+          if (!supervisorExists) {
+            log.info("{} with requestedWorkerCpu {} and requestedWorkerMem {} plus the requirements to launch a supervisor does not fit onto {} with resources {}",
+                     topologyDetails.getId(), requestedWorkerCpu, requestedWorkerMemInt, aggregatedOffers.getHostname(), aggregatedOffers.toString());
+          } else {
+            log.info("{} with requestedWorkerCpu {} and requestedWorkerMem {} does not fit onto {} with resources {}",
+                     topologyDetails.getId(), requestedWorkerCpu, requestedWorkerMemInt, aggregatedOffers.getHostname(), aggregatedOffers.toString());
+          }
           continue;
         }
 


### PR DESCRIPTION
Before this change it was possible to get the following unintuitive log line:
```
2017-08-08T02:49:30.956+0000 s.m.s.StormSchedulerImpl [INFO] sample-topology with requestedWorkerCpu 1.0 and requestedWorkerMem 1000 does not fit onto worker1 with resources cpus: 1.0 (dynamic: 0.0, static: 0.0, unreserved: 1.0), mem: 87671.0 (dynamic: 0.0, static: 0.0, unreserved: 87671.0), ports: [31004-31014,31024-31025,31027-32000,31003-31003]
```

This happens because [inside the call](https://github.com/mesos/storm/blob/f9513151d87bc7590e38c99a06ba5a617b513312/storm/src/main/storm/mesos/resources/AggregatedOffers.java#L170-L180) to `isFit` supervisor resources are added to the request depending on the setting for `supervisorExists`. This means that while it may _look_ like an offer will be a fit based on this log line (which is produced outside of the call to `isFit`), it may not _actually_ be able to fit because the log line does not account for supervisor resources.

To compensate for that, this fix prints out a log line that also indicates when there is a need for a supervisor to be launched.

As confirmed by looking at the tests (but hand-hacked for consistency), the line above would print the following when there is a supervisor present:
```
2017-08-08T02:49:30.956+0000 s.m.s.StormSchedulerImpl [INFO] sample-topology with requestedWorkerCpu 1.0 and requestedWorkerMem 1000 does not fit onto worker1 with resources cpus: 1.0 (dynamic: 0.0, static: 0.0, unreserved: 1.0), mem: 87671.0 (dynamic: 0.0, static: 0.0, unreserved: 87671.0), ports: [31004-31014,31024-31025,31027-32000,31003-31003]
```
And the following when there isn't a supervisor present:
```
2017-08-08T02:49:30.956+0000 s.m.s.StormSchedulerImpl [INFO] sample-topology with requestedWorkerCpu 1.0 and requestedWorkerMem 1000 plus the requirements to launch a supervisor does not fit onto worker1 with resources cpus: 1.0 (dynamic: 0.0, static: 0.0, unreserved: 1.0), mem: 87671.0 (dynamic: 0.0, static: 0.0, unreserved: 87671.0), ports: [31004-31014,31024-31025,31027-32000,31003-31003]

```