### PR TITLE
docker-engine package has been replaced with docker-ce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
   global:
   - DOCKER_REPO=$TRAVIS_REPO_SLUG
 before_install:
-- apt-cache madison docker-engine
-- travis_retry sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine
+- apt-cache madison docker-ce
+- travis_retry sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true
 script:
 - jdk_switcher use oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true
 script:
 - jdk_switcher use oraclejdk8
 - mvn test
-- jdk_switcher use oraclejdk7
+- jdk_switcher use openjdk7
 - mvn test
 - travis_retry bin/build-release.sh
 matrix:


### PR DESCRIPTION
Trying to get the travis-ci build to succeed.