### PR TITLE
Automated logviewer launch for 0.x

### DIFF
--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -203,6 +203,16 @@
       <artifactId>storm-shim</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-recipes</artifactId>
+      <version>2.12.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>2.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -42,6 +42,7 @@ import org.apache.mesos.Protos.OfferID;
 import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Protos.TaskInfo;
+import org.apache.mesos.Protos.TaskStatus;
 import org.apache.mesos.Protos.Value.Range;
 import org.apache.mesos.Protos.Value.Ranges;
 import org.apache.mesos.Protos.Value.Scalar;
@@ -86,6 +87,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Timer;
+import java.util.TimerTask;
 
 import static storm.mesos.util.PrettyProtobuf.offerIDListToString;
 import static storm.mesos.util.PrettyProtobuf.offerToString;
@@ -109,9 +112,13 @@ public class MesosNimbus implements INimbus {
   public static final String CONF_MESOS_CONTAINER_DOCKER_IMAGE = "mesos.container.docker.image";
   public static final String CONF_MESOS_SUPERVISOR_STORM_LOCAL_DIR = "mesos.supervisor.storm.local.dir";
   public static final String FRAMEWORK_ID = "FRAMEWORK_ID";
+  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = "|";
 
   public static final String CONF_ZOOKEEPER_SERVERS = "storm.zookeeper.servers";
   public static final String CONF_ZOOKEEPER_PORT = "storm.zookeeper.port";
+  public static final String CONF_STORM_LOGVIEWER_ZK_DIR = "storm.logviewer.zookeeper.dir";
+
+  public static final int TASK_RECONCILIATION_INTERVAL = 300000; // 5 minutes
 
   private static final Logger LOG = LoggerFactory.getLogger(MesosNimbus.class);
   private final Object _offersLock = new Object();
@@ -121,6 +128,7 @@ public class MesosNimbus implements INimbus {
   protected volatile SchedulerDriver _driver;
   private volatile boolean _registeredAndInitialized = false;
   private ZKClient _zkClient;
+  private String _logviewerZkDir;
   private Timer _timer = new Timer();
   private Map mesosStormConf;
   private Set<String> _allowedHosts;
@@ -220,13 +228,14 @@ public class MesosNimbus implements INimbus {
     if (zooKeeperPort == null || zooKeeperServers == null) {
       LOG.error("ZooKeeper configs are not found in storm.yaml");
     } else {
-      String connectionString = "";
+      StringBuilder connectionString = new StringBuilder();
       for (String server : zooKeeperServers) {
-        connectionString += server + ":" + zooKeeperPort + ",";
+        connectionString.append(String.format("%s:%s,", server, zooKeeperPort));
       }
       _zkClient = new ZKClient(connectionString.substring(0, connectionString.length() - 1));
-      if (!_zkClient.nodeExists("/logviewers")) {
-        _zkClient.createNode("/logviewers");
+      if (!_zkClient.nodeExists(_logviewerZkDir)) {
+        _zkClient.createNode(_logviewerZkDir);
+        LOG.info("Created general ZK directory for logviewer state at: {}", _logviewerZkDir);
       }
     }
 
@@ -236,7 +245,7 @@ public class MesosNimbus implements INimbus {
     }
 
     _container = Optional.fromNullable((String) conf.get(CONF_MESOS_CONTAINER_DOCKER_IMAGE));
-    _mesosScheduler = new NimbusMesosScheduler(this);
+    _mesosScheduler = new NimbusMesosScheduler(this, _zkClient, _logviewerZkDir);
 
     // Generate YAML to be served up to clients
     _generatedConfPath = Paths.get(
@@ -276,6 +285,17 @@ public class MesosNimbus implements INimbus {
 
     _state.put(FRAMEWORK_ID, id.getValue());
     _offers = new HashMap<Protos.OfferID, Protos.Offer>();
+
+    _timer.scheduleAtFixedRate(new TimerTask() {
+      @Override
+      public void run() {
+        // performing "implicit" reconciliation; master will respond with the latest state for all currently known
+        // non-terminal tasks
+        Collection<TaskStatus> taskStatuses = new ArrayList<TaskStatus>();
+        _driver.reconcileTasks(taskStatuses);
+        LOG.info("Performing tasking reconciliation between scheduler and master");
+      }
+    }, TASK_RECONCILIATION_INTERVAL, TASK_RECONCILIATION_INTERVAL); // reconciliation performed every 5 minutes
   }
 
   public void shutdown() throws Exception {
@@ -354,7 +374,9 @@ public class MesosNimbus implements INimbus {
       return new ArrayList<WorkerSlot>();
     }
     synchronized (_offersLock) {
-      launchLogviewer(existingSupervisors);
+      if (!_container.isPresent()) {
+        launchLogviewer(existingSupervisors);
+      }
       return _stormScheduler.allSlotsAvailableForScheduling(
               _offers,
               existingSupervisors,
@@ -389,9 +411,9 @@ public class MesosNimbus implements INimbus {
       List<TaskInfo> logviewerTask = new ArrayList<TaskInfo>();
       LOG.info("launchLogviewer: Supervisor ID: {}", supervisor.getId());
 
-      String nodeId = supervisor.getId().split("|")[0];
+      String nodeId = supervisor.getId().split("\\" + DEFAULT_MESOS_COMPONENT_NAME_DELIMITER)[0];
 
-      if (_zkClient.nodeExists(String.format("/logviewers/%s", nodeId))) {
+      if (_zkClient.nodeExists(String.format("%s/%s", _logviewerZkDir, nodeId))) {
         LOG.info("launchLogviewer: Logviewer already exists on this host: {}", nodeId);
         continue;
       }
@@ -423,7 +445,7 @@ public class MesosNimbus implements INimbus {
               .setValue(logviewerCommand);
 
       TaskID taskId = TaskID.newBuilder()
-              .setValue(String.format("%s-logviewer", nodeId))
+              .setValue(String.format("%s%slogviewer",  nodeId, DEFAULT_MESOS_COMPONENT_NAME_DELIMITER))
               .build();
 
       TaskInfo task = TaskInfo.newBuilder()
@@ -443,9 +465,9 @@ public class MesosNimbus implements INimbus {
         _offers.remove(offerID);
       }
 
-      String logviewerZKNodeName = String.format("/logviewers/%s", nodeId);
-      _zkClient.createNode(logviewerZKNodeName);
-      LOG.info("launchLogviewer: Updating logviewer state in zk: {}", logviewerZKNodeName);
+      String logviewerZKPath = String.format("%s/%s", _logviewerZkDir, nodeId);
+      _zkClient.createNode(logviewerZKPath);
+      LOG.info("launchLogviewer: Create logviewer state in zk: {}", logviewerZKPath);
     }
   }
 
@@ -812,9 +834,5 @@ public class MesosNimbus implements INimbus {
       credential = credentialBuilder.build();
     }
     return credential;
-  }
-
-  private void createLogviewer() {
-
   }
 }

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -385,6 +385,8 @@ public class MesosNimbus implements INimbus {
     final double logviewerMem = 400.0;
 
     Map<String, AggregatedOffers> aggregatedOffersPerNode = MesosCommon.getAggregatedOffersPerNode(_offers);
+    StormSchedulerImpl stormScheduler = (StormSchedulerImpl) getForcedScheduler();
+    boolean needLogviewer = false;
 
     String supervisorStormLocalDir = getStormLocalDirForWorkers();
     String configUri = getFullConfigUri();
@@ -421,6 +423,7 @@ public class MesosNimbus implements INimbus {
       AggregatedOffers aggregatedOffers = aggregatedOffersPerNode.get(nodeId);
       if (aggregatedOffers == null) {
         LOG.info("launchLogviewer: No offers for this host: {}", nodeId);
+        needLogviewer = true;
         continue;
       }
 
@@ -481,6 +484,12 @@ public class MesosNimbus implements INimbus {
       String logviewerZKPath = String.format("%s/%s", _logviewerZkDir, nodeId);
       _zkClient.createNode(logviewerZKPath);
       LOG.info("launchLogviewer: Create logviewer state in zk: {}", logviewerZKPath);
+    }
+    if (needLogviewer) {
+      LOG.info("launchLogviewer: No offers for logviewer, requesting offers");
+      stormScheduler.addOfferRequest(MesosCommon.LOGVIEWER_OFFERS_REQUEST_KEY);
+    } else {
+      stormScheduler.removeOfferRequest(MesosCommon.LOGVIEWER_OFFERS_REQUEST_KEY);
     }
   }
 

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -443,7 +443,7 @@ public class MesosNimbus implements INimbus {
         _offers.remove(offerID);
       }
 
-      String logviewerZKNodeName = String.format("/logviewers/%s", nodeId));
+      String logviewerZKNodeName = String.format("/logviewers/%s", nodeId);
       _zkClient.createNode(logviewerZKNodeName);
       LOG.info("launchLogviewer: Updating logviewer state in zk: {}", logviewerZKNodeName);
     }

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -110,6 +110,7 @@ public class MesosNimbus implements INimbus {
   public static final String CONF_MESOS_CHECKPOINT = "mesos.framework.checkpoint";
   public static final String CONF_MESOS_LOCAL_FILE_SERVER_PORT = "mesos.local.file.server.port";
   public static final String CONF_MESOS_FRAMEWORK_NAME = "mesos.framework.name";
+  public static final String CONF_MESOS_FRAMEWORK_USER = "mesos.framework.user";
   public static final String CONF_MESOS_PREFER_RESERVED_RESOURCES = "mesos.prefer.reserved.resources";
   public static final String CONF_MESOS_CONTAINER_DOCKER_IMAGE = "mesos.container.docker.image";
   public static final String CONF_MESOS_SUPERVISOR_STORM_LOCAL_DIR = "mesos.supervisor.storm.local.dir";
@@ -810,7 +811,6 @@ public class MesosNimbus implements INimbus {
     Number failoverTimeout = Optional.fromNullable((Number) mesosStormConf.get(CONF_MASTER_FAILOVER_TIMEOUT_SECS)).or(24 * 7 * 3600);
     String role = Optional.fromNullable((String) mesosStormConf.get(CONF_MESOS_ROLE)).or("*");
     Boolean checkpoint = Optional.fromNullable((Boolean) mesosStormConf.get(CONF_MESOS_CHECKPOINT)).or(false);
-    String frameworkName = Optional.fromNullable((String) mesosStormConf.get(CONF_MESOS_FRAMEWORK_NAME)).or("Storm!!!");
     String frameworkUser = Optional.fromNullable((String) mesosStormConf.get(CONF_MESOS_FRAMEWORK_USER)).or("");
     FrameworkInfo.Builder finfo = FrameworkInfo.newBuilder()
                                                .setName(frameworkName)

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -63,6 +63,7 @@ import storm.mesos.shims.CommandLineShimFactory;
 import storm.mesos.shims.ICommandLineShim;
 import storm.mesos.shims.LocalStateShim;
 import storm.mesos.util.MesosCommon;
+import storm.mesos.util.ZKClient;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -108,6 +109,10 @@ public class MesosNimbus implements INimbus {
   public static final String CONF_MESOS_CONTAINER_DOCKER_IMAGE = "mesos.container.docker.image";
   public static final String CONF_MESOS_SUPERVISOR_STORM_LOCAL_DIR = "mesos.supervisor.storm.local.dir";
   public static final String FRAMEWORK_ID = "FRAMEWORK_ID";
+
+  public static final String CONF_ZOOKEEPER_SERVERS = "storm.zookeeper.servers";
+  public static final String CONF_ZOOKEEPER_PORT = "storm.zookeeper.port";
+
   private static final Logger LOG = LoggerFactory.getLogger(MesosNimbus.class);
   private final Object _offersLock = new Object();
   protected java.net.URI _configUrl;
@@ -115,6 +120,8 @@ public class MesosNimbus implements INimbus {
   private NimbusMesosScheduler _mesosScheduler;
   protected volatile SchedulerDriver _driver;
   private volatile boolean _registeredAndInitialized = false;
+  private ZKClient _zkClient;
+  private Timer _timer = new Timer();
   private Map mesosStormConf;
   private Set<String> _allowedHosts;
   private Set<String> _disallowedHosts;
@@ -204,6 +211,25 @@ public class MesosNimbus implements INimbus {
 
     _allowedHosts = listIntoSet((List<String>) conf.get(CONF_MESOS_ALLOWED_HOSTS));
     _disallowedHosts = listIntoSet((List<String>) conf.get(CONF_MESOS_DISALLOWED_HOSTS));
+
+    Set<String> zooKeeperServers = listIntoSet((List<String>) conf.get(Config.STORM_ZOOKEEPER_SERVERS));
+    String zooKeeperPort = String.valueOf(conf.get(Config.STORM_ZOOKEEPER_PORT));
+    _logviewerZkDir = Optional.fromNullable((String) conf.get(Config.STORM_ZOOKEEPER_ROOT)).or("") + "/storm-mesos/logviewers";
+    LOG.info("Logviewer information will be stored under {}", _logviewerZkDir);
+
+    if (zooKeeperPort == null || zooKeeperServers == null) {
+      LOG.error("ZooKeeper configs are not found in storm.yaml");
+    } else {
+      String connectionString = "";
+      for (String server : zooKeeperServers) {
+        connectionString += server + ":" + zooKeeperPort + ",";
+      }
+      _zkClient = new ZKClient(connectionString.substring(0, connectionString.length() - 1));
+      if (!_zkClient.nodeExists("/logviewers")) {
+        _zkClient.createNode("/logviewers");
+      }
+    }
+
     Boolean preferReservedResources = (Boolean) conf.get(CONF_MESOS_PREFER_RESERVED_RESOURCES);
     if (preferReservedResources != null) {
       _preferReservedResources = preferReservedResources;
@@ -328,11 +354,98 @@ public class MesosNimbus implements INimbus {
       return new ArrayList<WorkerSlot>();
     }
     synchronized (_offersLock) {
+      launchLogviewer(existingSupervisors);
       return _stormScheduler.allSlotsAvailableForScheduling(
               _offers,
               existingSupervisors,
               topologies,
               topologiesMissingAssignments);
+    }
+  }
+
+  private void launchLogviewer(Collection<SupervisorDetails> existingSupervisors) {
+    final double logviewerCpu = 0.5;
+    final double logviewerMem = 400.0;
+
+    Map<String, AggregatedOffers> aggregatedOffersPerNode = MesosCommon.getAggregatedOffersPerNode(_offers);
+
+    String supervisorStormLocalDir = getStormLocalDirForWorkers();
+    String configUri = getFullConfigUri();
+    String logviewerCommand = String.format(
+                    "cp storm.yaml storm-mesos*/conf" +
+                    " && cd storm-mesos*" +
+                    " && bin/storm logviewer" +
+                    " -c storm.local.dir=%s", supervisorStormLocalDir);
+
+    /**
+     *  Go through each existing supervisor and:
+     *    1. Check ZK if logviewer already exists on worker host, if not then continue
+     *    2. Look in the aggregratedOffersPerNode and check the node for offers, if there are offers then continue
+     *    3. Create a TaskInfo for the logviewer corresponding to the correct Offers and launch the task
+     *    4. Update ZK to reflect the existence of new logviewer on worker host
+     */
+
+    for (SupervisorDetails supervisor : existingSupervisors) {
+      List<TaskInfo> logviewerTask = new ArrayList<TaskInfo>();
+      LOG.info("launchLogviewer: Supervisor ID: {}", supervisor.getId());
+
+      String nodeId = supervisor.getId().split("|")[0];
+
+      if (_zkClient.nodeExists(String.format("/logviewers/%s", nodeId))) {
+        LOG.info("launchLogviewer: Logviewer already exists on this host: {}", nodeId);
+        continue;
+      }
+
+      AggregatedOffers aggregatedOffers = aggregatedOffersPerNode.get(nodeId);
+      if (aggregatedOffers == null) {
+        LOG.info("launchLogviewer: No offers for this host: {}", nodeId);
+        continue;
+      }
+
+      List<OfferID> offerIDList = aggregatedOffers.getOfferIDList();
+
+      List<Resource> resources = new ArrayList<Resource>();
+      List<ResourceEntry> resourceEntryList = null;
+
+      try {
+        resourceEntryList = aggregatedOffers.reserveAndGet(ResourceType.CPU, new ScalarResourceEntry(logviewerCpu));
+        resources.addAll(createMesosScalarResourceList(ResourceType.CPU, resourceEntryList));
+        resourceEntryList = aggregatedOffers.reserveAndGet(ResourceType.MEM, new ScalarResourceEntry(logviewerMem));
+        resources.addAll(createMesosScalarResourceList(ResourceType.MEM, resourceEntryList));
+      } catch (ResourceNotAvailableException e) {
+        LOG.warn("launchLogviewer: Unable to launch logviewer because some resources were unavailable. Available aggregatedOffers: %s", aggregatedOffers);
+        continue;
+      }
+
+      CommandInfo.Builder commandInfoBuilder = CommandInfo.newBuilder()
+              .addUris(URI.newBuilder().setValue((String) mesosStormConf.get(CONF_EXECUTOR_URI)))
+              .addUris(URI.newBuilder().setValue(configUri))
+              .setValue(logviewerCommand);
+
+      TaskID taskId = TaskID.newBuilder()
+              .setValue(String.format("%s-logviewer", nodeId))
+              .build();
+
+      TaskInfo task = TaskInfo.newBuilder()
+              .setTaskId(taskId)
+              .setName("logviewer")
+              .setSlaveId(aggregatedOffers.getSlaveID())
+              .setCommand(commandInfoBuilder.build())
+              .addAllResources(resources)
+              .build();
+
+      logviewerTask.add(task);
+
+      LOG.info("launchLogviewer: Using offerIDs: {} on host: {} to launch logviewer", offerIDListToString(offerIDList), nodeId);
+
+      _driver.launchTasks(offerIDList, logviewerTask);
+      for (OfferID offerID : offerIDList) {
+        _offers.remove(offerID);
+      }
+
+      String logviewerZKNodeName = String.format("/logviewers/%s", nodeId));
+      _zkClient.createNode(logviewerZKNodeName);
+      LOG.info("launchLogviewer: Updating logviewer state in zk: {}", logviewerZKNodeName);
     }
   }
 
@@ -699,5 +812,9 @@ public class MesosNimbus implements INimbus {
       credential = credentialBuilder.build();
     }
     return credential;
+  }
+
+  private void createLogviewer() {
+
   }
 }

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -112,11 +112,7 @@ public class MesosNimbus implements INimbus {
   public static final String CONF_MESOS_CONTAINER_DOCKER_IMAGE = "mesos.container.docker.image";
   public static final String CONF_MESOS_SUPERVISOR_STORM_LOCAL_DIR = "mesos.supervisor.storm.local.dir";
   public static final String FRAMEWORK_ID = "FRAMEWORK_ID";
-  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = "|";
-
-  public static final String CONF_ZOOKEEPER_SERVERS = "storm.zookeeper.servers";
-  public static final String CONF_ZOOKEEPER_PORT = "storm.zookeeper.port";
-  public static final String CONF_STORM_LOGVIEWER_ZK_DIR = "storm.logviewer.zookeeper.dir";
+  public static final String CONF_STORM_MESOS_LOGVIEWER_ZK_DIR = "storm.mesos.logviewer.zookeeper.dir";
 
   public static final int TASK_RECONCILIATION_INTERVAL = 300000; // 5 minutes
 
@@ -137,6 +133,7 @@ public class MesosNimbus implements INimbus {
   private Map<OfferID, Offer> _offers;
   private LocalFileServer _httpServer;
   private IMesosStormScheduler _stormScheduler = null;
+  private String frameworkName;
 
   private boolean _preferReservedResources = true;
   private Optional<String> _container = Optional.absent();
@@ -211,6 +208,8 @@ public class MesosNimbus implements INimbus {
     mesosStormConf = new HashMap();
     mesosStormConf.putAll(conf);
 
+    frameworkName = MesosCommon.getMesosFrameworkName(conf);
+
     try {
       _state = new LocalStateShim(localDir);
     } catch (IOException exp) {
@@ -233,10 +232,6 @@ public class MesosNimbus implements INimbus {
         connectionString.append(String.format("%s:%s,", server, zooKeeperPort));
       }
       _zkClient = new ZKClient(connectionString.substring(0, connectionString.length() - 1));
-      if (!_zkClient.nodeExists(_logviewerZkDir)) {
-        _zkClient.createNode(_logviewerZkDir);
-        LOG.info("Created general ZK directory for logviewer state at: {}", _logviewerZkDir);
-      }
     }
 
     Boolean preferReservedResources = (Boolean) conf.get(CONF_MESOS_PREFER_RESERVED_RESOURCES);
@@ -411,7 +406,12 @@ public class MesosNimbus implements INimbus {
       List<TaskInfo> logviewerTask = new ArrayList<TaskInfo>();
       LOG.info("launchLogviewer: Supervisor ID: {}", supervisor.getId());
 
-      String nodeId = supervisor.getId().split("\\" + DEFAULT_MESOS_COMPONENT_NAME_DELIMITER)[0];
+      if (!supervisor.getId().contains(MesosCommon.MESOS_COMPONENT_ID_DELIMITER)) {
+        LOG.error("launchLogviewer: Supervisor ID formatting invalid, please re-launch all supervisors");
+        continue;
+      }
+
+      String nodeId = supervisor.getId().split("\\" + MesosCommon.MESOS_COMPONENT_ID_DELIMITER)[1];
 
       if (_zkClient.nodeExists(String.format("%s/%s", _logviewerZkDir, nodeId))) {
         LOG.info("launchLogviewer: Logviewer already exists on this host: {}", nodeId);
@@ -444,13 +444,26 @@ public class MesosNimbus implements INimbus {
               .addUris(URI.newBuilder().setValue(configUri))
               .setValue(logviewerCommand);
 
+      // i.e. "Storm!!!|worker-host4.dev|logviewer-1504045609.983"
+      String id = String.format("%s%s%s%slogviewer-%s",
+                                frameworkName,
+                                MesosCommon.MESOS_COMPONENT_ID_DELIMITER,
+                                nodeId,
+                                MesosCommon.MESOS_COMPONENT_ID_DELIMITER,
+                                MesosCommon.timestampMillis());
       TaskID taskId = TaskID.newBuilder()
-              .setValue(String.format("%s%slogviewer",  nodeId, DEFAULT_MESOS_COMPONENT_NAME_DELIMITER))
+              .setValue(id)
               .build();
 
+      // i.e. "Storm!!! | logviewer | 8888"
+      String name = String.format("%s%slogviewer%s%s",
+                                  frameworkName,
+                                  MesosCommon.DEFAULT_MESOS_COMPONENT_NAME_DELIMITER,
+                                  MesosCommon.DEFAULT_MESOS_COMPONENT_NAME_DELIMITER,
+                                  mesosStormConf.get(Config.LOGVIEWER_PORT));
       TaskInfo task = TaskInfo.newBuilder()
               .setTaskId(taskId)
-              .setName("logviewer")
+              .setName(name)
               .setSlaveId(aggregatedOffers.getSlaveID())
               .setCommand(commandInfoBuilder.build())
               .addAllResources(resources)
@@ -678,12 +691,12 @@ public class MesosNimbus implements INimbus {
         }
 
         Map executorData = new HashMap();
-        executorData.put(MesosCommon.SUPERVISOR_ID, MesosCommon.supervisorId(slot.getNodeId(), topologyDetails.getId()));
+        executorData.put(MesosCommon.SUPERVISOR_ID, MesosCommon.supervisorId(frameworkName, slot.getNodeId(), topologyDetails.getId()));
         executorData.put(MesosCommon.ASSIGNMENT_ID, workerPrefix + slot.getNodeId());
 
         String topologyAndNodeId = topologyDetails.getId() + " | " + slot.getNodeId();
-        String executorName = "storm-supervisor | " + topologyAndNodeId;
-        String taskName = "storm-worker | " + topologyAndNodeId + ":" + slot.getPort();
+        String executorName = frameworkName + " | supervisor | " + topologyAndNodeId;
+        String taskName = frameworkName + " | worker | " + topologyAndNodeId + ":" + slot.getPort();
         String executorDataStr = JSONValue.toJSONString(executorData);
         String extraConfig = "";
 
@@ -768,7 +781,7 @@ public class MesosNimbus implements INimbus {
     String role = Optional.fromNullable((String) mesosStormConf.get(CONF_MESOS_ROLE)).or("*");
     Boolean checkpoint = Optional.fromNullable((Boolean) mesosStormConf.get(CONF_MESOS_CHECKPOINT)).or(false);
     String frameworkName = Optional.fromNullable((String) mesosStormConf.get(CONF_MESOS_FRAMEWORK_NAME)).or("Storm!!!");
-
+    String frameworkUser = Optional.fromNullable((String) mesosStormConf.get(CONF_MESOS_FRAMEWORK_USER)).or("");
     FrameworkInfo.Builder finfo = FrameworkInfo.newBuilder()
         .setName(frameworkName)
         .setFailoverTimeout(failoverTimeout.doubleValue())

--- a/storm/src/main/storm/mesos/NimbusMesosScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusMesosScheduler.java
@@ -123,7 +123,7 @@ public class NimbusMesosScheduler implements Scheduler {
   private void updateLogviewerState(TaskStatus status) {
     String taskId = status.getTaskId().getValue();
     if (!taskId.contains(MesosCommon.MESOS_COMPONENT_ID_DELIMITER)) {
-      LOG.error("updateLogviewerState: taskId for logviewer, {}, isn't formatted correctly", taskId);
+      LOG.error("updateLogviewerState: taskId for logviewer, {}, isn't formatted correctly so ignoring task update", taskId);
       return;
     }
     String nodeId = taskId.split("\\" + MesosCommon.MESOS_COMPONENT_ID_DELIMITER)[1];
@@ -139,6 +139,7 @@ public class NimbusMesosScheduler implements Scheduler {
         checkRunningLogviewerState(logviewerZKPath);
         return;
       case TASK_LOST:
+        // this status update can be triggered by the explicit kill and isn't terminal, do not kill again
         break;
       default:
         // explicitly kill the logviewer task to ensure logviewer is terminated

--- a/storm/src/main/storm/mesos/NimbusMesosScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusMesosScheduler.java
@@ -30,6 +30,7 @@ import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import storm.mesos.schedulers.StormSchedulerImpl;
+import storm.mesos.util.MesosCommon;
 import storm.mesos.util.ZKClient;
 
 import java.util.List;
@@ -43,7 +44,6 @@ public class NimbusMesosScheduler implements Scheduler {
   private String logviewerZkDir;
   private CountDownLatch _registeredLatch = new CountDownLatch(1);
   public static final Logger LOG = LoggerFactory.getLogger(MesosNimbus.class);
-  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = "|";
 
   public NimbusMesosScheduler(MesosNimbus mesosNimbus, ZKClient zkClient, String logviewerZkDir) {
     this.mesosNimbus = mesosNimbus;
@@ -138,10 +138,12 @@ public class NimbusMesosScheduler implements Scheduler {
       case TASK_RUNNING:
         checkRunningLogviewerState(logviewerZKPath);
         return;
+      case TASK_LOST:
+        break;
       default:
+        // explicitly kill the logviewer task to ensure logviewer is terminated
+        mesosNimbus._driver.killTask(status.getTaskId());
     }
-    // explicitly kill the logviewer task to ensure logviewer is terminated
-    mesosNimbus._driver.killTask(status.getTaskId());
     // if it gets to this point it means logviewer terminated; update ZK with new logviewer state
     if (zkClient.nodeExists(logviewerZKPath)) {
       LOG.info("updateLogviewerState: Remove logviewer state in zk at {} for logviewer task {}", logviewerZKPath, taskId);

--- a/storm/src/main/storm/mesos/NimbusMesosScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusMesosScheduler.java
@@ -29,6 +29,7 @@ import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import storm.mesos.schedulers.StormSchedulerImpl;
 import storm.mesos.util.ZKClient;
 
 import java.util.List;

--- a/storm/src/main/storm/mesos/NimbusMesosScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusMesosScheduler.java
@@ -29,6 +29,7 @@ import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import storm.mesos.util.ZKClient;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -37,11 +38,16 @@ import static storm.mesos.util.PrettyProtobuf.taskStatusToString;
 
 public class NimbusMesosScheduler implements Scheduler {
   private MesosNimbus mesosNimbus;
+  private ZKClient zkClient;
+  private String logviewerZkDir;
   private CountDownLatch _registeredLatch = new CountDownLatch(1);
   public static final Logger LOG = LoggerFactory.getLogger(MesosNimbus.class);
+  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = "|";
 
-  public NimbusMesosScheduler(MesosNimbus mesosNimbus) {
+  public NimbusMesosScheduler(MesosNimbus mesosNimbus, ZKClient zkClient, String logviewerZkDir) {
     this.mesosNimbus = mesosNimbus;
+    this.zkClient = zkClient;
+    this.logviewerZkDir = logviewerZkDir;
   }
 
   public void waitUntilRegistered() throws InterruptedException {
@@ -89,6 +95,9 @@ public class NimbusMesosScheduler implements Scheduler {
   @Override
   public void statusUpdate(SchedulerDriver driver, TaskStatus status) {
     String msg = String.format("Received status update: %s", taskStatusToString(status));
+    if (status.getTaskId().getValue().contains("logviewer")) {
+      updateLogviewerState(status);
+    }
     switch (status.getState()) {
       case TASK_STAGING:
       case TASK_STARTING:

--- a/storm/src/main/storm/mesos/NimbusMesosScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusMesosScheduler.java
@@ -110,6 +110,45 @@ public class NimbusMesosScheduler implements Scheduler {
     }
   }
 
+  private void updateLogviewerState(TaskStatus status) {
+    String taskId = status.getTaskId().getValue();
+    if (!taskId.contains(MesosCommon.MESOS_COMPONENT_ID_DELIMITER)) {
+      LOG.error("updateLogviewerState: taskId for logviewer, {}, isn't formatted correctly", taskId);
+      return;
+    }
+    String nodeId = taskId.split("\\" + MesosCommon.MESOS_COMPONENT_ID_DELIMITER)[1];
+    String logviewerZKPath = String.format("%s/%s", logviewerZkDir, nodeId);
+    switch (status.getState()) {
+      case TASK_STAGING:
+        checkRunningLogviewerState(logviewerZKPath);
+        return;
+      case TASK_STARTING:
+        checkRunningLogviewerState(logviewerZKPath);
+        return;
+      case TASK_RUNNING:
+        checkRunningLogviewerState(logviewerZKPath);
+        return;
+      default:
+    }
+    // explicitly kill the logviewer task to ensure logviewer is terminated
+    mesosNimbus._driver.killTask(status.getTaskId());
+    // if it gets to this point it means logviewer terminated; update ZK with new logviewer state
+    if (zkClient.nodeExists(logviewerZKPath)) {
+      LOG.info("updateLogviewerState: Remove logviewer state in zk at {} for logviewer task {}", logviewerZKPath, taskId);
+      zkClient.deleteNode(logviewerZKPath);
+      LOG.info("updateLogviewerState: Add offer request for logviewer");
+      StormSchedulerImpl stormScheduler = (StormSchedulerImpl) mesosNimbus.getForcedScheduler();
+      stormScheduler.addOfferRequest(MesosCommon.LOGVIEWER_OFFERS_REQUEST_KEY);
+    }
+  }
+
+  private void checkRunningLogviewerState(String logviewerZKPath) {
+    if (!zkClient.nodeExists(logviewerZKPath)) {
+      LOG.error("checkRunningLogviewerState: Running mesos logviewer task exists for logviewer that isn't tracked in ZooKeeper");
+      zkClient.createNode(logviewerZKPath);
+    }
+  }
+
   @Override
   public void frameworkMessage(SchedulerDriver driver, ExecutorID executorId, SlaveID slaveId, byte[] data) {
   }

--- a/storm/src/main/storm/mesos/schedulers/SchedulerUtils.java
+++ b/storm/src/main/storm/mesos/schedulers/SchedulerUtils.java
@@ -91,9 +91,9 @@ public class SchedulerUtils {
    * @param topologyId ID of topology requiring assignment
    * @return boolean value indicating supervisor existence
    */
-  public static boolean supervisorExists(String offerHost, Collection<SupervisorDetails> existingSupervisors,
+  public static boolean supervisorExists(String frameworkName, String offerHost, Collection<SupervisorDetails> existingSupervisors,
                                    String topologyId) {
-    String expectedSupervisorId = MesosCommon.supervisorId(offerHost, topologyId);
+    String expectedSupervisorId = MesosCommon.supervisorId(frameworkName, offerHost, topologyId);
     for (SupervisorDetails supervisorDetail : existingSupervisors) {
       if (supervisorDetail.getId().equals(expectedSupervisorId)) {
         return true;

--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -70,6 +70,14 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
     mesosStormConf = conf;
   }
 
+  public void setOffersSuppressed() {
+    offersSuppressed = true;
+  }
+
+  public void unsetOffersSuppressed() {
+    offersSuppressed = false;
+  }
+
   private List<MesosWorkerSlot> getMesosWorkerSlots(Map<String, AggregatedOffers> aggregatedOffersPerNode,
                                                     Collection<String> nodesWithExistingSupervisors,
                                                     TopologyDetails topologyDetails) {
@@ -161,7 +169,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
       if (!offersSuppressed) {
         log.info("(SUPPRESS OFFERS) We don't have any topologies that need assignments, but offers are still flowing. Suppressing offers.");
         driver.suppressOffers();
-        offersSuppressed = true;
+        setOffersSuppressed();
       }
 =======
       log.info("Declining all offers that are currently buffered because no topologies need assignments");
@@ -194,7 +202,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
       if (offersSuppressed) {
         log.info("(REVIVE OFFERS) We have topologies that need assignments, but offers are currently suppressed. Reviving offers.");
         driver.reviveOffers();
-        offersSuppressed = false;
+        unsetOffersSuppressed();
       }
       // Note: We still have the offersLock at this point, so we return the empty ArrayList so that we can release the lock and acquire new offers
       return new ArrayList<>();

--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -165,14 +165,14 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
     }
     if (offersRequestTracker.isEmpty()) {
       if (!offers.isEmpty()) {
-        log.info("Declining all offers that are currently buffered because no topologies or tasks need assignments. Declined offer ids: {}", offerMapKeySetToString(offers));
+        log.info("Declining all offers that are currently buffered because no topologies nor tasks need assignments. Declined offer ids: {}", offerMapKeySetToString(offers));
         for (Protos.OfferID offerId : offers.keySet()) {
           driver.declineOffer(offerId);
         }
         offers.clear();
       }
       if (!offersSuppressed) {
-        log.info("(SUPPRESS OFFERS) We don't have any topologies or tasks that need assignments, but offers are still flowing. Suppressing offers.");
+        log.info("(SUPPRESS OFFERS) We don't have any topologies nor tasks that need assignments, but offers are still flowing. Suppressing offers.");
         driver.suppressOffers();
         offersSuppressed = true;
       }
@@ -203,7 +203,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
 
     if (offers.isEmpty()) {
       if (offersSuppressed) {
-        log.info("(REVIVE OFFERS) We have topologies or sidecar tasks that need assignments, but offers are currently suppressed. Reviving offers.");
+        log.info("(REVIVE OFFERS) We have topologies or tasks that need assignments, but offers are currently suppressed. Reviving offers.");
         driver.reviveOffers();
         offersSuppressed = false;
       }

--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -56,6 +56,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
   private final Map<String, MesosWorkerSlot> mesosWorkerSlotMap = new HashMap<>();
   private volatile boolean offersSuppressed = false;
   private SchedulerDriver driver;
+  private Set<String> offersRequestTracker = new HashSet<>();
 
   private StormSchedulerImpl() {
     // We make this constructor private so that calling it results in a compile time error
@@ -70,12 +71,12 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
     mesosStormConf = conf;
   }
 
-  public void setOffersSuppressed() {
-    offersSuppressed = true;
+  public void addOfferRequest(String key) {
+    offersRequestTracker.add(key);
   }
 
-  public void unsetOffersSuppressed() {
-    offersSuppressed = false;
+  public void removeOfferRequest(String key) {
+    offersRequestTracker.remove(key);
   }
 
   private List<MesosWorkerSlot> getMesosWorkerSlots(Map<String, AggregatedOffers> aggregatedOffersPerNode,
@@ -158,20 +159,23 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
                                                          Collection<SupervisorDetails> existingSupervisors,
                                                          Topologies topologies, Set<String> topologiesMissingAssignments) {
     if (topologiesMissingAssignments.isEmpty()) {
-<<<<<<< HEAD
+      removeOfferRequest(MesosCommon.TOPOLOGIES_OFFERS_REQUEST_KEY);
+    } else {
+      addOfferRequest(MesosCommon.TOPOLOGIES_OFFERS_REQUEST_KEY);
+    }
+    if (offersRequestTracker.isEmpty()) {
       if (!offers.isEmpty()) {
-        log.info("Declining all offers that are currently buffered because no topologies need assignments. Declined offer ids: {}", offerMapKeySetToString(offers));
+        log.info("Declining all offers that are currently buffered because no topologies or tasks need assignments. Declined offer ids: {}", offerMapKeySetToString(offers));
         for (Protos.OfferID offerId : offers.keySet()) {
           driver.declineOffer(offerId);
         }
         offers.clear();
       }
       if (!offersSuppressed) {
-        log.info("(SUPPRESS OFFERS) We don't have any topologies that need assignments, but offers are still flowing. Suppressing offers.");
+        log.info("(SUPPRESS OFFERS) We don't have any topologies or tasks that need assignments, but offers are still flowing. Suppressing offers.");
         driver.suppressOffers();
-        setOffersSuppressed();
+        offersSuppressed = true;
       }
-=======
       log.info("Declining all offers that are currently buffered because no topologies need assignments");
       for (Protos.OfferID offerId : offers.keySet()) {
         driver.declineOffer(offerId);
@@ -192,7 +196,6 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
         offersSuppressed = false;
       }
       // Note: We still have the offersLock at this point, so we return the empty ArrayList so that we can release the lock and acquire new offers
->>>>>>> Stop accumulating offers in a RotatingMap, instead suppress offers when we don't need them and revive offers when we do need them.
       return new ArrayList<>();
     }
 
@@ -200,9 +203,9 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
 
     if (offers.isEmpty()) {
       if (offersSuppressed) {
-        log.info("(REVIVE OFFERS) We have topologies that need assignments, but offers are currently suppressed. Reviving offers.");
+        log.info("(REVIVE OFFERS) We have topologies or sidecar tasks that need assignments, but offers are currently suppressed. Reviving offers.");
         driver.reviveOffers();
-        unsetOffersSuppressed();
+        offersSuppressed = false;
       }
       // Note: We still have the offersLock at this point, so we return the empty ArrayList so that we can release the lock and acquire new offers
       return new ArrayList<>();

--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -150,6 +150,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
                                                          Collection<SupervisorDetails> existingSupervisors,
                                                          Topologies topologies, Set<String> topologiesMissingAssignments) {
     if (topologiesMissingAssignments.isEmpty()) {
+<<<<<<< HEAD
       if (!offers.isEmpty()) {
         log.info("Declining all offers that are currently buffered because no topologies need assignments. Declined offer ids: {}", offerMapKeySetToString(offers));
         for (Protos.OfferID offerId : offers.keySet()) {
@@ -162,6 +163,28 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
         driver.suppressOffers();
         offersSuppressed = true;
       }
+=======
+      log.info("Declining all offers that are currently buffered because no topologies need assignments");
+      for (Protos.OfferID offerId : offers.keySet()) {
+        driver.declineOffer(offerId);
+      }
+      offers.clear();
+      // Since we don't have any topologies that need assignments, we will suppress Offers from Mesos as we do not need more
+      if (!offersSuppressed) {
+        driver.suppressOffers();
+        offersSuppressed = true;
+      }
+      return new ArrayList<>();
+    }
+
+    if (offers.isEmpty()) {
+      if (offersSuppressed) {
+        // Since we had previously suppressed Offers, and we now have topologies needing assignment, we will revive offers from Mesos
+        driver.reviveOffers();
+        offersSuppressed = false;
+      }
+      // Note: We still have the offersLock at this point, so we return the empty ArrayList so that we can release the lock and acquire new offers
+>>>>>>> Stop accumulating offers in a RotatingMap, instead suppress offers when we don't need them and revive offers when we do need them.
       return new ArrayList<>();
     }
 

--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -222,7 +222,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
 
       Set<String> nodesWithExistingSupervisors = new HashSet<>();
       for (String currentNode : aggregatedOffersPerNode.keySet()) {
-        if (SchedulerUtils.supervisorExists(currentNode, existingSupervisors, currentTopology)) {
+        if (SchedulerUtils.supervisorExists(MesosCommon.getMesosFrameworkName(mesosStormConf), currentNode, existingSupervisors, currentTopology)) {
           nodesWithExistingSupervisors.add(currentNode);
         }
       }

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -104,7 +104,7 @@ public class MesosCommon {
   }
 
   public static String supervisorId(String nodeid, String topologyId) {
-    return String.format("%s-%s", nodeid, topologyId);
+    return String.format("%s|%s", nodeid, topologyId);
   }
 
   public static boolean autoStartLogViewer(Map conf) {

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -59,7 +59,7 @@ public class MesosCommon {
   public static final String SUPERVISOR_ID = "supervisorid";
   public static final String ASSIGNMENT_ID = "assignmentid";
   public static final String DEFAULT_WORKER_NAME_PREFIX_DELIMITER = "_";
-  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = " | ";
+  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = "|";
 
   public static String getNimbusHost(Map mesosStormConf) throws UnknownHostException {
     Optional<String> nimbusHostFromConfig =  Optional.fromNullable((String) mesosStormConf.get(Config.NIMBUS_HOST));
@@ -104,7 +104,7 @@ public class MesosCommon {
   }
 
   public static String supervisorId(String nodeid, String topologyId) {
-    return String.format("%s|%s", nodeid, topologyId);
+    return String.format("%s%s%s", nodeid, DEFAULT_MESOS_COMPONENT_NAME_DELIMITER, topologyId);
   }
 
   public static boolean autoStartLogViewer(Map conf) {

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -23,6 +23,8 @@ import com.google.common.base.Optional;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import storm.mesos.MesosNimbus;
 import storm.mesos.resources.AggregatedOffers;
 
 import java.net.InetAddress;
@@ -59,7 +61,12 @@ public class MesosCommon {
   public static final String SUPERVISOR_ID = "supervisorid";
   public static final String ASSIGNMENT_ID = "assignmentid";
   public static final String DEFAULT_WORKER_NAME_PREFIX_DELIMITER = "_";
-  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = "|";
+  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = " | ";
+  public static final String MESOS_COMPONENT_ID_DELIMITER = "|";
+
+  public static String getMesosFrameworkName(Map mesosStormConf) {
+    return Optional.fromNullable((String) mesosStormConf.get(MesosNimbus.CONF_MESOS_FRAMEWORK_NAME)).or("Storm!!!");
+  }
 
   public static String getNimbusHost(Map mesosStormConf) throws UnknownHostException {
     Optional<String> nimbusHostFromConfig =  Optional.fromNullable((String) mesosStormConf.get(Config.NIMBUS_HOST));
@@ -103,8 +110,8 @@ public class MesosCommon {
     return String.format("%s-%d-%s", nodeid, port, timestampMillis());
   }
 
-  public static String supervisorId(String nodeid, String topologyId) {
-    return String.format("%s%s%s", nodeid, DEFAULT_MESOS_COMPONENT_NAME_DELIMITER, topologyId);
+  public static String supervisorId(String frameworkName, String nodeid, String topologyId) {
+    return String.format("%s%s%s%s%s", frameworkName, MESOS_COMPONENT_ID_DELIMITER, nodeid, MESOS_COMPONENT_ID_DELIMITER, topologyId);
   }
 
   public static boolean autoStartLogViewer(Map conf) {

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -64,6 +64,9 @@ public class MesosCommon {
   public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = " | ";
   public static final String MESOS_COMPONENT_ID_DELIMITER = "|";
 
+  public static final String LOGVIEWER_OFFERS_REQUEST_KEY = "logviewer";
+  public static final String TOPOLOGIES_OFFERS_REQUEST_KEY = "topologies";
+
   public static String getMesosFrameworkName(Map mesosStormConf) {
     return Optional.fromNullable((String) mesosStormConf.get(MesosNimbus.CONF_MESOS_FRAMEWORK_NAME)).or("Storm!!!");
   }

--- a/storm/src/main/storm/mesos/util/ZKClient.java
+++ b/storm/src/main/storm/mesos/util/ZKClient.java
@@ -1,0 +1,117 @@
+package storm.mesos.util;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.CuratorListener;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ZKClient allows you to interact with ZooKeeper. Primarily used for tracking logviewer state on hosts thus far but
+ * can be used to track any metadata needed in the future.
+ */
+
+public class ZKClient {
+  CuratorFramework _client;
+  public static final Logger LOG = LoggerFactory.getLogger(ZKClient.class);
+  private static final int BASE_SLEEP_TIME_MS = 1000;
+  private static final int MAX_RETRIES = 3;
+
+  public ZKClient() {
+    ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_RETRIES);
+    _client = CuratorFrameworkFactory.newClient("localhost:2181", retryPolicy);
+    _client.start();
+  }
+
+  public ZKClient(String connectionString) {
+    LOG.info("Attempting to connect to following ZooKeeper servers: {}", connectionString);
+    ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_RETRIES);
+    _client = CuratorFrameworkFactory.newClient(connectionString, retryPolicy);
+    _client.start();
+  }
+
+  public ZKClient(String connectionString, int connectionTimeout, int sessionTimeout) {
+    LOG.info("Attempting to connect to following ZooKeeper servers: {}", connectionString);
+    ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_RETRIES);
+    _client = CuratorFrameworkFactory.builder()
+                                     .connectString(connectionString)
+                                     .retryPolicy(retryPolicy)
+                                     .connectionTimeoutMs(connectionTimeout)
+                                     .sessionTimeoutMs(sessionTimeout)
+                                     .build();
+    _client.start();
+  }
+
+  public boolean createNode(String path, String data) {
+    try {
+      _client.create().creatingParentsIfNeeded().forPath(path, data.getBytes());
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public boolean createNode(String path) {
+    try {
+      // default payload of byte[0]
+      _client.create().creatingParentsIfNeeded().forPath(path);
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public void deleteNode(String path) {
+    try {
+      // the delete is guaranteed even if initial failure, curator will attempt to delete in background until successful
+      _client.delete().guaranteed().forPath(path);
+    } catch (Exception e) {
+      // swallow exception because delete is guaranteed
+    }
+  }
+
+  public boolean updateNodeData(String path, String data) {
+    try {
+      _client.setData().forPath(path, data.getBytes());
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public String getNodeData(String path) {
+    byte[] rawData = null;
+    try {
+      rawData = _client.getData().forPath(path);
+      return new String(rawData, "UTF-8");
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return "";
+    }
+  }
+
+  public boolean nodeExists(String path) {
+    try {
+      Stat stat = _client.checkExists().forPath(path);
+      if (stat == null) {
+        return false;
+      }
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public void close() {
+    _client.close();
+  }
+}

--- a/storm/src/main/storm/mesos/util/ZKClient.java
+++ b/storm/src/main/storm/mesos/util/ZKClient.java
@@ -11,6 +11,8 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 /**
  * ZKClient allows you to interact with ZooKeeper. Primarily used for tracking logviewer state on hosts thus far but
  * can be used to track any metadata needed in the future.
@@ -87,15 +89,24 @@ public class ZKClient {
     }
   }
 
-  public String getNodeData(String path) {
+  public boolean updateNodeData(String path, byte[] data) {
+    try {
+      _client.setData().forPath(path, data);
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public byte[] getNodeData(String path) {
     byte[] rawData = null;
     try {
       rawData = _client.getData().forPath(path);
-      return new String(rawData, "UTF-8");
     } catch (Exception e) {
       LOG.error(e.toString());
-      return "";
     }
+    return rawData;
   }
 
   public boolean nodeExists(String path) {
@@ -109,6 +120,16 @@ public class ZKClient {
       LOG.error(e.toString());
       return false;
     }
+  }
+
+  public List<String> getChildren(String path) {
+    List<String> children = null;
+    try {
+      children = _client.getChildren().forPath(path);
+    } catch (Exception e) {
+      LOG.error(e.toString());
+    }
+    return children;
   }
 
   public void close() {

--- a/storm/src/test/storm/mesos/MesosCommonTest.java
+++ b/storm/src/test/storm/mesos/MesosCommonTest.java
@@ -153,7 +153,7 @@ public class MesosCommonTest {
     String nodeid = "nodeID1";
     String topologyid = "t1";
     String result = MesosCommon.supervisorId(nodeid, topologyid);
-    String expectedResult = nodeid + "-" + topologyid;
+    String expectedResult = nodeid + "|" + topologyid;
     assertEquals(result, expectedResult);
   }
 

--- a/storm/src/test/storm/mesos/MesosCommonTest.java
+++ b/storm/src/test/storm/mesos/MesosCommonTest.java
@@ -150,10 +150,11 @@ public class MesosCommonTest {
 
   @Test
   public void testSupervisorId() throws Exception {
+    String frameworkName = "Storm!!!";
     String nodeid = "nodeID1";
     String topologyid = "t1";
-    String result = MesosCommon.supervisorId(nodeid, topologyid);
-    String expectedResult = nodeid + "|" + topologyid;
+    String result = MesosCommon.supervisorId(frameworkName, nodeid, topologyid);
+    String expectedResult = frameworkName + "|" + nodeid + "|" + topologyid;
     assertEquals(result, expectedResult);
   }
 

--- a/storm/src/test/storm/mesos/MesosNimbusTest.java
+++ b/storm/src/test/storm/mesos/MesosNimbusTest.java
@@ -180,7 +180,7 @@ public class MesosNimbusTest {
 
   private String getTopologyIdFromTaskName(String taskName) {
     String info[] = taskName.split("\\|");
-    return info[1];
+    return info[2];
   }
 
   private Map<String, List<Protos.TaskInfo>> getTopologyIDtoTaskInfoMap(List<Protos.TaskInfo> taskInfoList) {

--- a/storm/src/test/storm/mesos/ZKClientTest.java
+++ b/storm/src/test/storm/mesos/ZKClientTest.java
@@ -1,5 +1,6 @@
 package storm.mesos;
 
+import org.apache.mesos.Protos;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.junit.After;
@@ -7,6 +8,8 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import storm.mesos.util.ZKClient;
 import org.apache.curator.test.TestingServer;
+
+import java.util.List;
 
 public class ZKClientTest {
   /**
@@ -69,7 +72,7 @@ public class ZKClientTest {
     success = target.createNode(pathName, initialString);
     assertTrue("Couldn't create node", success);
 
-    String returnedString = target.getNodeData(pathName);
+    String returnedString = new String(target.getNodeData(pathName));
     assertTrue("Data retrieved doesn't match initial data", initialString.equals(returnedString));
 
     target.deleteNode(pathName);
@@ -89,7 +92,7 @@ public class ZKClientTest {
     success = target.updateNodeData(pathName, updatedString);
     assertTrue("Couldn't update node data", success);
 
-    String returnedString = target.getNodeData(pathName);
+    String returnedString = new String(target.getNodeData(pathName));
     assertTrue("Data retrieved doesn't match updated data", updatedString.equals(returnedString));
 
     target.deleteNode(pathName);
@@ -119,6 +122,78 @@ public class ZKClientTest {
 
     target.deleteNode(parentPath);
     assertFalse("Parent node unsuccessfully deleted", target.nodeExists(parentPath));
+  }
+
+  @Test
+  public void testGetChildrenOfParentNode() {
+    boolean success = false;
+    String parentPath = "/parent";
+    String nestedPathOne = "/parent/childOne";
+    String nestedPathTwo = "/parent/childTwo";
+
+    success = target.createNode(nestedPathOne);
+    assertTrue("Failed to create parent and child node", success);
+
+    assertTrue("Parent node was not created", target.nodeExists(parentPath));
+
+    success = target.createNode(nestedPathTwo);
+    assertTrue("Failed to create second node under parent", success);
+
+    List<String> childrenPaths = target.getChildren(parentPath);
+    assertTrue("childOne path not successfully retrieved", childrenPaths.contains(nestedPathOne.split("\\/")[2]));
+    assertTrue("childTwo path not successfully retrieved", childrenPaths.contains(nestedPathTwo.split("\\/")[2]));
+    assertFalse("Random path retrieved when not created", childrenPaths.contains("random"));
+
+    target.deleteNode(nestedPathOne);
+    assertFalse("First child node unsuccessfully deleted", target.nodeExists(nestedPathOne));
+
+    target.deleteNode(nestedPathTwo);
+    assertFalse("Second child node unsuccessfully deleted", target.nodeExists(nestedPathTwo));
+
+    target.deleteNode(parentPath);
+    assertFalse("Parent node unsuccessfully deleted", target.nodeExists(parentPath));
+  }
+
+  @Test
+  public void testTrackingTastStatusData() {
+    boolean success = false;
+    String path = "/taskStatus";
+    String id = "id";
+    Protos.TaskID taskId = Protos.TaskID.newBuilder()
+                                        .setValue(id)
+                                        .build();
+    Protos.TaskStatus status = Protos.TaskStatus.newBuilder()
+                                                .setTaskId(taskId)
+                                                .setState(Protos.TaskState.TASK_RUNNING)
+                                                .build();
+
+    success = target.createNode(path);
+    assertTrue("Failed to create node at specified path", success);
+
+    success = target.updateNodeData(path, id);
+    assertTrue("Failed to update node data at specified path", success);
+
+    Protos.TaskID taskIdClone = Protos.TaskID.newBuilder()
+                                             .setValue(new String(target.getNodeData(path)))
+                                             .build();
+    Protos.TaskStatus statusClone = Protos.TaskStatus.newBuilder()
+                                                .setTaskId(taskIdClone)
+                                                .setState(Protos.TaskState.TASK_RUNNING)
+                                                .build();
+
+    Protos.TaskID taskIdFake = Protos.TaskID.newBuilder()
+            .setValue("fake")
+            .build();
+    Protos.TaskStatus statusFake = Protos.TaskStatus.newBuilder()
+            .setTaskId(taskIdFake)
+            .setState(Protos.TaskState.TASK_RUNNING)
+            .build();
+
+    assertTrue("TaskStatus objects stored in ZooKeeper do not match existing ones", status.equals(statusClone));
+    assertFalse("Fake TaskStatus objects match the ones stored in ZooKeeper", status.equals(statusFake));
+
+    target.deleteNode(path);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(path));
   }
 
   @After

--- a/storm/src/test/storm/mesos/ZKClientTest.java
+++ b/storm/src/test/storm/mesos/ZKClientTest.java
@@ -1,0 +1,131 @@
+package storm.mesos;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.junit.After;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import storm.mesos.util.ZKClient;
+import org.apache.curator.test.TestingServer;
+
+/**
+ * Created by rtang on 7/21/17.
+ */
+public class ZKClientTest {
+  /**
+   * Testing target.
+   */
+  private final ZKClient target;
+
+  /**
+   * Setup testing target & sample data.
+   */
+  public ZKClientTest() {
+    String connString = "localhost:2181";
+    try {
+      TestingServer server = new TestingServer(true);
+      connString = server.getConnectString();
+    } catch (Exception e) {
+      assertTrue("Couldn't create test server", false);
+    }
+    target = new ZKClient(connString);
+  }
+
+  @Test
+  public void testCreateNodeThenDelete() {
+    boolean success = false;
+    String pathName = "/test1";
+
+    success = target.createNode(pathName);
+    assertTrue("Couldn't create node", success);
+
+    target.deleteNode(pathName);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCreateNodeCheckExistenceThenDelete() {
+    boolean success = false;
+    String pathName = "/test2";
+
+    success = target.createNode(pathName);
+    assertTrue("Couldn't create node", success);
+
+    assertTrue("Node created but doesn't exist", target.nodeExists(pathName));
+
+    target.deleteNode(pathName);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCheckExistenceOfNonexistentNode() {
+    String pathName = "/test3";
+    assertFalse("Nonexistent node exists for some reason", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCreateNodeGetDataThenDelete() {
+    boolean success = false;
+    String pathName = "/test4";
+    String initialString = "test";
+
+    success = target.createNode(pathName, initialString);
+    assertTrue("Couldn't create node", success);
+
+    String returnedString = target.getNodeData(pathName);
+    assertTrue("Data retrieved doesn't match initial data", initialString.equals(returnedString));
+
+    target.deleteNode(pathName);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCreateNodeUpdateDataThenDelete() {
+    boolean success = false;
+    String pathName = "/test5";
+    String initialString = "test";
+
+    success = target.createNode(pathName, initialString);
+    assertTrue("Couldn't create node", success);
+
+    String updatedString = "updated";
+    success = target.updateNodeData(pathName, updatedString);
+    assertTrue("Couldn't update node data", success);
+
+    String returnedString = target.getNodeData(pathName);
+    assertTrue("Data retrieved doesn't match updated data", updatedString.equals(returnedString));
+
+    target.deleteNode(pathName);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCreateNestedNodeThenDelete() {
+    boolean success = false;
+    String parentPath = "/parent";
+    String nestedPathOne = "/parent/childOne";
+    String nestedPathTwo = "/parent/childTwo";
+
+    success = target.createNode(nestedPathOne);
+    assertTrue("Failed to create parent and child node", success);
+
+    assertTrue("Parent node was not created", target.nodeExists(parentPath));
+
+    success = target.createNode(nestedPathTwo);
+    assertTrue("Failed to create second node under parent", success);
+
+    target.deleteNode(nestedPathOne);
+    assertFalse("First child node unsuccessfully deleted", target.nodeExists(nestedPathOne));
+
+    target.deleteNode(nestedPathTwo);
+    assertFalse("Second child node unsuccessfully deleted", target.nodeExists(nestedPathTwo));
+
+    target.deleteNode(parentPath);
+    assertFalse("Parent node unsuccessfully deleted", target.nodeExists(parentPath));
+  }
+
+  @After
+  public void closeConnection() {
+    target.close();
+  }
+}

--- a/storm/src/test/storm/mesos/ZKClientTest.java
+++ b/storm/src/test/storm/mesos/ZKClientTest.java
@@ -8,9 +8,6 @@ import static org.junit.Assert.*;
 import storm.mesos.util.ZKClient;
 import org.apache.curator.test.TestingServer;
 
-/**
- * Created by rtang on 7/21/17.
- */
 public class ZKClientTest {
   /**
    * Testing target.

--- a/storm/src/test/storm/mesos/schedulers/SchedulerUtilsTest.java
+++ b/storm/src/test/storm/mesos/schedulers/SchedulerUtilsTest.java
@@ -54,11 +54,12 @@ public class SchedulerUtilsTest {
   public void testSupervisorExists() throws Exception {
     Collection<SupervisorDetails> existingSupervisors = new ArrayList<>();
     String hostName = "host1.east";
+    String frameworkName = "Storm!!!";
 
-    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(hostName, "test-topology1-65-1442255385"), hostName, null));
-    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(hostName, "test-topology10-65-1442255385"), hostName, null));
+    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(frameworkName, hostName, "test-topology1-65-1442255385"), hostName));
+    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(frameworkName, hostName, "test-topology10-65-1442255385"), hostName));
 
-    assertEquals(true, SchedulerUtils.supervisorExists(hostName, existingSupervisors, "test-topology1-65-1442255385"));
-    assertEquals(false, SchedulerUtils.supervisorExists(hostName, existingSupervisors, "test-topology2-65-1442255385"));
+    assertEquals(true, SchedulerUtils.supervisorExists(frameworkName, hostName, existingSupervisors, "test-topology1-65-1442255385"));
+    assertEquals(false, SchedulerUtils.supervisorExists(frameworkName, hostName, existingSupervisors, "test-topology2-65-1442255385"));
   }
 }

--- a/storm/src/test/storm/mesos/schedulers/StormSchedulerImplTest.java
+++ b/storm/src/test/storm/mesos/schedulers/StormSchedulerImplTest.java
@@ -69,6 +69,7 @@ public class StormSchedulerImplTest {
   private SchedulerDriver driver;
   private final String sampleTopologyId = "test-topology1-65-1442255385";
   private final String sampleHost = "host1.example.org";
+  private final String sampleFrameworkName = "Storm!!!";
   private final int samplePort = 3100;
 
   private Cluster getSpyCluster() {
@@ -159,8 +160,8 @@ public class StormSchedulerImplTest {
     topologiesMissingAssignments.add("test-topology1-65-1442255385");
 
     existingSupervisors = new ArrayList<>();
-    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(sampleHost, "test-topology1-65-1442255385"), sampleHost, null, null));
-    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(sampleHost, "test-topology10-65-1442255385"), sampleHost, null, null));
+    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(sampleFrameworkName, sampleHost, "test-topology1-65-1442255385"), sampleHost, null, null));
+    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(sampleFrameworkName, sampleHost, "test-topology10-65-1442255385"), sampleHost, null, null));
 
     topologyMap = new HashMap<>();
     topologyMap.put(sampleTopologyId, TestUtils.constructTopologyDetails(sampleTopologyId, 1, 0.1, 100));


### PR DESCRIPTION
#### Notes
- Automated logviewer launch on any worker hosts running Storm bits (0.x specific)
- State of these logviewer daemons are tracked per host by stuffing state into ZooKeeper
- Reconciliation is also implemented to ensure that logviewers are brought back alive if ever killed.

#### ZKClient.java
- Wrapper around Apache Curator in order to interact with ZK
- Can create, delete, and check for existence of nodes in ZK
- Used to track which hosts are running logviewer daemons by tracking that state into ZK
- Junit tests are written for this class

#### MesosNimbus.java
- Added TimerTask to perform implicit reconciliation every 5 minutes
  - Implicit reconciliation reconciles that state of every running task between the framework scheduler and master (sends update of task status to *statusUpdate* method in *NimbusMesosScheduler*)
- *launchLogviewer* method called in *allSlotsAvailableForScheduling* loops through the *existingSupervisors* and schedules the logviewer daemon as Mesos tasks based on the offers available on each host
  - Checks ZK if logviewer already running on the host which the supervisor is running on, as such, ensures that logviewer only runs on hosts with Storm bits

#### NimbusMesosScheduler.java
- Updated *statusUpdate* method to look for logviewer tasks to check if they need to be relaunched
- *updateLogviewerState* method updates the state of the logviewer task in ZK if needed
  - *reviveOffers* if logviewer needs to be relaunched

#### storm.yaml
- Added new config called *storm.logviewer.zookeeper.dir* which allows you to configure under which "path" you want the logviewer state to be stored in ZK