### PR TITLE
backport fixes for CI builds to storm-0.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_deploy:
 - travis_retry make images
 - travis_retry make images JAVA_PRODUCT_VERSION=8
 - docker images
-- travis_retry docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+- travis_retry docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 - travis_retry make push
 - travis_retry make push JAVA_PRODUCT_VERSION=8
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
   global:
   - DOCKER_REPO=$TRAVIS_REPO_SLUG
 before_install:
-- apt-cache madison docker-engine
-- travis_retry sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine
+- apt-cache madison docker-ce
+- travis_retry sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true
 script:
 - jdk_switcher use oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true
 script:
 - jdk_switcher use oraclejdk8
 - mvn test
-- jdk_switcher use oraclejdk7
+- jdk_switcher use openjdk7
 - mvn test
 - travis_retry bin/build-release.sh
 matrix:


### PR DESCRIPTION
Ran these commands:

```
% git checkout storm-0.x
% git cherry-pick b3d3b02ab1349edd56aaf25af77fd580bb93fa0f b78aad789c52e5a5e4487488c7d061c331cdf9e4 8de8a75f856b850675299e8479da483e1607d20d
% git push origin storm-0.x
# Where the push remote for origin was erikdw/storm-mesos
```