### PR TITLE
Automated logviewer launch for 1.x

### DIFF
--- a/storm/pom.xml
+++ b/storm/pom.xml
@@ -197,6 +197,16 @@
       <artifactId>storm-shim</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-recipes</artifactId>
+      <version>2.12.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>2.12.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -111,7 +111,6 @@ public class MesosNimbus implements INimbus {
   public static final String CONF_MESOS_CONTAINER_DOCKER_IMAGE = "mesos.container.docker.image";
   public static final String CONF_MESOS_SUPERVISOR_STORM_LOCAL_DIR = "mesos.supervisor.storm.local.dir";
   public static final String FRAMEWORK_ID = "FRAMEWORK_ID";
-  public static final String CONF_STORM_MESOS_LOGVIEWER_ZK_DIR = "storm.mesos.logviewer.zookeeper.dir";
 
   public static final int TASK_RECONCILIATION_INTERVAL = 300000; // 5 minutes
 
@@ -284,10 +283,10 @@ public class MesosNimbus implements INimbus {
       @Override
       public void run() {
         // performing "implicit" reconciliation; master will respond with the latest state for all currently known
-        // non-terminal tasks
+        // non-terminal tasks in the framework scheduler's statusUpdate() method
         Collection<TaskStatus> taskStatuses = new ArrayList<TaskStatus>();
         _driver.reconcileTasks(taskStatuses);
-        LOG.info("Performing tasking reconciliation between scheduler and master");
+        LOG.info("Performing task reconciliation between scheduler and master");
       }
     }, TASK_RECONCILIATION_INTERVAL, TASK_RECONCILIATION_INTERVAL); // reconciliation performed every 5 minutes
   }
@@ -368,6 +367,10 @@ public class MesosNimbus implements INimbus {
       return new ArrayList<WorkerSlot>();
     }
     synchronized (_offersLock) {
+      /**
+       *  Not currently supporting automated logviewer launch for Docker containers
+       *  ISSUE #215: https://github.com/mesos/storm/issues/215
+       */
       if (!_container.isPresent()) {
         launchLogviewer(existingSupervisors);
       }
@@ -381,7 +384,7 @@ public class MesosNimbus implements INimbus {
 
   private void launchLogviewer(Collection<SupervisorDetails> existingSupervisors) {
     final double logviewerCpu = 0.5;
-    final double logviewerMem = 400.0;
+    final double logviewerMemMb = 400.0;
 
     Map<String, AggregatedOffers> aggregatedOffersPerNode = MesosCommon.getAggregatedOffersPerNode(_offers);
     StormSchedulerImpl stormScheduler = (StormSchedulerImpl) getForcedScheduler();
@@ -389,33 +392,32 @@ public class MesosNimbus implements INimbus {
 
     String supervisorStormLocalDir = getStormLocalDirForWorkers();
     String configUri = getFullConfigUri();
-    String logviewerCommand = String.format(
-                    "cp storm.yaml storm-mesos*/conf" +
-                    " && cd storm-mesos*" +
-                    " && bin/storm logviewer" +
-                    " -c storm.local.dir=%s", supervisorStormLocalDir);
+    String logviewerCommand = String.format("cp storm.yaml storm-mesos*/conf" +
+                                            " && cd storm-mesos*" +
+                                            " && bin/storm logviewer" +
+                                            " -c storm.local.dir=%s", supervisorStormLocalDir);
 
     /**
      *  Go through each existing supervisor and:
-     *    1. Check ZK if logviewer already exists on worker host, if not then continue
-     *    2. Look in the aggregratedOffersPerNode and check the node for offers, if there are offers then continue
+     *    1. Check ZK if logviewer already exists on worker host, if not then proceed
+     *    2. Look in the aggregratedOffersPerNode and check the node for offers, if there are offers then proceed
      *    3. Create a TaskInfo for the logviewer corresponding to the correct Offers and launch the task
      *    4. Update ZK to reflect the existence of new logviewer on worker host
      */
 
     for (SupervisorDetails supervisor : existingSupervisors) {
       List<TaskInfo> logviewerTask = new ArrayList<TaskInfo>();
-      LOG.info("launchLogviewer: Supervisor ID: {}", supervisor.getId());
 
       if (!supervisor.getId().contains(MesosCommon.MESOS_COMPONENT_ID_DELIMITER)) {
-        LOG.error("launchLogviewer: Supervisor ID formatting invalid, please re-launch all supervisors");
+        LOG.error("launchLogviewer: Supervisor ID, {}, formatting invalid, please re-launch all supervisors", supervisor.getId());
         continue;
       }
 
+      // No current mapping exists from supervisor ID to node ID so that information must be extracted and stored in the
+      // supervisor ID
       String nodeId = supervisor.getId().split("\\" + MesosCommon.MESOS_COMPONENT_ID_DELIMITER)[1];
 
       if (_zkClient.nodeExists(String.format("%s/%s", _logviewerZkDir, nodeId))) {
-        LOG.info("launchLogviewer: Logviewer already exists on this host: {}", nodeId);
         continue;
       }
 
@@ -434,7 +436,7 @@ public class MesosNimbus implements INimbus {
       try {
         resourceEntryList = aggregatedOffers.reserveAndGet(ResourceType.CPU, new ScalarResourceEntry(logviewerCpu));
         resources.addAll(createMesosScalarResourceList(ResourceType.CPU, resourceEntryList));
-        resourceEntryList = aggregatedOffers.reserveAndGet(ResourceType.MEM, new ScalarResourceEntry(logviewerMem));
+        resourceEntryList = aggregatedOffers.reserveAndGet(ResourceType.MEM, new ScalarResourceEntry(logviewerMemMb));
         resources.addAll(createMesosScalarResourceList(ResourceType.MEM, resourceEntryList));
       } catch (ResourceNotAvailableException e) {
         LOG.warn("launchLogviewer: Unable to launch logviewer because some resources were unavailable. Available aggregatedOffers: %s", aggregatedOffers);
@@ -442,9 +444,9 @@ public class MesosNimbus implements INimbus {
       }
 
       CommandInfo.Builder commandInfoBuilder = CommandInfo.newBuilder()
-              .addUris(URI.newBuilder().setValue((String) mesosStormConf.get(CONF_EXECUTOR_URI)))
-              .addUris(URI.newBuilder().setValue(configUri))
-              .setValue(logviewerCommand);
+                                                          .addUris(URI.newBuilder().setValue((String) mesosStormConf.get(CONF_EXECUTOR_URI)))
+                                                          .addUris(URI.newBuilder().setValue(configUri))
+                                                          .setValue(logviewerCommand);
 
       // i.e. "Storm!!!|worker-host4.dev|logviewer-1504045609.983"
       String id = String.format("%s%s%s%slogviewer-%s",
@@ -454,8 +456,8 @@ public class MesosNimbus implements INimbus {
                                 MesosCommon.MESOS_COMPONENT_ID_DELIMITER,
                                 MesosCommon.timestampMillis());
       TaskID taskId = TaskID.newBuilder()
-              .setValue(id)
-              .build();
+                            .setValue(id)
+                            .build();
 
       // i.e. "Storm!!! | logviewer | 8888"
       String name = String.format("%s%slogviewer%s%s",
@@ -464,16 +466,16 @@ public class MesosNimbus implements INimbus {
                                   MesosCommon.DEFAULT_MESOS_COMPONENT_NAME_DELIMITER,
                                   mesosStormConf.get(Config.LOGVIEWER_PORT));
       TaskInfo task = TaskInfo.newBuilder()
-              .setTaskId(taskId)
-              .setName(name)
-              .setSlaveId(aggregatedOffers.getSlaveID())
-              .setCommand(commandInfoBuilder.build())
-              .addAllResources(resources)
-              .build();
+                              .setTaskId(taskId)
+                              .setName(name)
+                              .setSlaveId(aggregatedOffers.getSlaveID())
+                              .setCommand(commandInfoBuilder.build())
+                              .addAllResources(resources)
+                              .build();
 
       logviewerTask.add(task);
 
-      LOG.info("launchLogviewer: Using offerIDs: {} on host: {} to launch logviewer", offerIDListToString(offerIDList), nodeId);
+      LOG.info("launchLogviewer: Using offerIDs: {} on host: {} to launch logviewer task: {}", offerIDListToString(offerIDList), nodeId, task.getTaskId().getValue());
 
       _driver.launchTasks(offerIDList, logviewerTask);
       for (OfferID offerID : offerIDList) {
@@ -488,6 +490,7 @@ public class MesosNimbus implements INimbus {
       LOG.info("launchLogviewer: No offers for logviewer, requesting offers");
       stormScheduler.addOfferRequest(MesosCommon.LOGVIEWER_OFFERS_REQUEST_KEY);
     } else {
+      LOG.info("launchLogviewer: Logviewer already running on all hosts containing storm bits");
       stormScheduler.removeOfferRequest(MesosCommon.LOGVIEWER_OFFERS_REQUEST_KEY);
     }
   }
@@ -791,11 +794,11 @@ public class MesosNimbus implements INimbus {
     String frameworkUser = Optional.fromNullable((String) mesosStormConf.get(CONF_MESOS_FRAMEWORK_USER)).or("");
 
     FrameworkInfo.Builder finfo = FrameworkInfo.newBuilder()
-        .setName(frameworkName)
-        .setFailoverTimeout(failoverTimeout.doubleValue())
-        .setUser(frameworkUser)
-        .setRole(role)
-        .setCheckpoint(checkpoint);
+                                               .setName(frameworkName)
+                                               .setFailoverTimeout(failoverTimeout.doubleValue())
+                                               .setUser(frameworkUser)
+                                               .setRole(role)
+                                               .setCheckpoint(checkpoint);
 
     String id = _state.get(FRAMEWORK_ID);
 

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -63,6 +63,7 @@ import storm.mesos.shims.CommandLineShimFactory;
 import storm.mesos.shims.ICommandLineShim;
 import storm.mesos.shims.LocalStateShim;
 import storm.mesos.util.MesosCommon;
+import storm.mesos.util.ZKClient;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -107,6 +108,10 @@ public class MesosNimbus implements INimbus {
   public static final String CONF_MESOS_CONTAINER_DOCKER_IMAGE = "mesos.container.docker.image";
   public static final String CONF_MESOS_SUPERVISOR_STORM_LOCAL_DIR = "mesos.supervisor.storm.local.dir";
   public static final String FRAMEWORK_ID = "FRAMEWORK_ID";
+
+  public static final String CONF_ZOOKEEPER_SERVERS = "storm.zookeeper.servers";
+  public static final String CONF_ZOOKEEPER_PORT = "storm.zookeeper.port";
+
   private static final Logger LOG = LoggerFactory.getLogger(MesosNimbus.class);
   private final Object _offersLock = new Object();
   protected java.net.URI _configUrl;
@@ -114,6 +119,8 @@ public class MesosNimbus implements INimbus {
   private NimbusMesosScheduler _mesosScheduler;
   protected volatile SchedulerDriver _driver;
   private volatile boolean _registeredAndInitialized = false;
+  private ZKClient _zkClient;
+  private Timer _timer = new Timer();
   private Map mesosStormConf;
   private Set<String> _allowedHosts;
   private Set<String> _disallowedHosts;
@@ -203,6 +210,25 @@ public class MesosNimbus implements INimbus {
 
     _allowedHosts = listIntoSet((List<String>) conf.get(CONF_MESOS_ALLOWED_HOSTS));
     _disallowedHosts = listIntoSet((List<String>) conf.get(CONF_MESOS_DISALLOWED_HOSTS));
+
+    Set<String> zooKeeperServers = listIntoSet((List<String>) conf.get(Config.STORM_ZOOKEEPER_SERVERS));
+    String zooKeeperPort = String.valueOf(conf.get(Config.STORM_ZOOKEEPER_PORT));
+    _logviewerZkDir = Optional.fromNullable((String) conf.get(Config.STORM_ZOOKEEPER_ROOT)).or("") + "/storm-mesos/logviewers";
+    LOG.info("Logviewer information will be stored under {}", _logviewerZkDir);
+
+    if (zooKeeperPort == null || zooKeeperServers == null) {
+      LOG.error("ZooKeeper configs are not found in storm.yaml");
+    } else {
+      String connectionString = "";
+      for (String server : zooKeeperServers) {
+        connectionString += server + ":" + zooKeeperPort + ",";
+      }
+      _zkClient = new ZKClient(connectionString.substring(0, connectionString.length() - 1));
+      if (!_zkClient.nodeExists("/logviewers")) {
+        _zkClient.createNode("/logviewers");
+      }
+    }
+
     Boolean preferReservedResources = (Boolean) conf.get(CONF_MESOS_PREFER_RESERVED_RESOURCES);
     if (preferReservedResources != null) {
       _preferReservedResources = preferReservedResources;
@@ -327,11 +353,98 @@ public class MesosNimbus implements INimbus {
       return new ArrayList<WorkerSlot>();
     }
     synchronized (_offersLock) {
+      launchLogviewer(existingSupervisors);
       return _stormScheduler.allSlotsAvailableForScheduling(
               _offers,
               existingSupervisors,
               topologies,
               topologiesMissingAssignments);
+    }
+  }
+
+  private void launchLogviewer(Collection<SupervisorDetails> existingSupervisors) {
+    final double logviewerCpu = 0.5;
+    final double logviewerMem = 400.0;
+
+    Map<String, AggregatedOffers> aggregatedOffersPerNode = MesosCommon.getAggregatedOffersPerNode(_offers);
+
+    String supervisorStormLocalDir = getStormLocalDirForWorkers();
+    String configUri = getFullConfigUri();
+    String logviewerCommand = String.format(
+                    "cp storm.yaml storm-mesos*/conf" +
+                    " && cd storm-mesos*" +
+                    " && bin/storm logviewer" +
+                    " -c storm.local.dir=%s", supervisorStormLocalDir);
+
+    /**
+     *  Go through each existing supervisor and:
+     *    1. Check ZK if logviewer already exists on worker host, if not then continue
+     *    2. Look in the aggregratedOffersPerNode and check the node for offers, if there are offers then continue
+     *    3. Create a TaskInfo for the logviewer corresponding to the correct Offers and launch the task
+     *    4. Update ZK to reflect the existence of new logviewer on worker host
+     */
+
+    for (SupervisorDetails supervisor : existingSupervisors) {
+      List<TaskInfo> logviewerTask = new ArrayList<TaskInfo>();
+      LOG.info("launchLogviewer: Supervisor ID: {}", supervisor.getId());
+
+      String nodeId = supervisor.getId().split("|")[0];
+
+      if (_zkClient.nodeExists(String.format("/logviewers/%s", nodeId))) {
+        LOG.info("launchLogviewer: Logviewer already exists on this host: {}", nodeId);
+        continue;
+      }
+
+      AggregatedOffers aggregatedOffers = aggregatedOffersPerNode.get(nodeId);
+      if (aggregatedOffers == null) {
+        LOG.info("launchLogviewer: No offers for this host: {}", nodeId);
+        continue;
+      }
+
+      List<OfferID> offerIDList = aggregatedOffers.getOfferIDList();
+
+      List<Resource> resources = new ArrayList<Resource>();
+      List<ResourceEntry> resourceEntryList = null;
+
+      try {
+        resourceEntryList = aggregatedOffers.reserveAndGet(ResourceType.CPU, new ScalarResourceEntry(logviewerCpu));
+        resources.addAll(createMesosScalarResourceList(ResourceType.CPU, resourceEntryList));
+        resourceEntryList = aggregatedOffers.reserveAndGet(ResourceType.MEM, new ScalarResourceEntry(logviewerMem));
+        resources.addAll(createMesosScalarResourceList(ResourceType.MEM, resourceEntryList));
+      } catch (ResourceNotAvailableException e) {
+        LOG.warn("launchLogviewer: Unable to launch logviewer because some resources were unavailable. Available aggregatedOffers: %s", aggregatedOffers);
+        continue;
+      }
+
+      CommandInfo.Builder commandInfoBuilder = CommandInfo.newBuilder()
+              .addUris(URI.newBuilder().setValue((String) mesosStormConf.get(CONF_EXECUTOR_URI)))
+              .addUris(URI.newBuilder().setValue(configUri))
+              .setValue(logviewerCommand);
+
+      TaskID taskId = TaskID.newBuilder()
+              .setValue(String.format("%s-logviewer", nodeId))
+              .build();
+
+      TaskInfo task = TaskInfo.newBuilder()
+              .setTaskId(taskId)
+              .setName("logviewer")
+              .setSlaveId(aggregatedOffers.getSlaveID())
+              .setCommand(commandInfoBuilder.build())
+              .addAllResources(resources)
+              .build();
+
+      logviewerTask.add(task);
+
+      LOG.info("launchLogviewer: Using offerIDs: {} on host: {} to launch logviewer", offerIDListToString(offerIDList), nodeId);
+
+      _driver.launchTasks(offerIDList, logviewerTask);
+      for (OfferID offerID : offerIDList) {
+        _offers.remove(offerID);
+      }
+
+      String logviewerZKNodeName = String.format("/logviewers/%s", nodeId));
+      _zkClient.createNode(logviewerZKNodeName);
+      LOG.info("launchLogviewer: Updating logviewer state in zk: {}", logviewerZKNodeName);
     }
   }
 
@@ -699,5 +812,9 @@ public class MesosNimbus implements INimbus {
       credential = credentialBuilder.build();
     }
     return credential;
+  }
+
+  private void createLogviewer() {
+
   }
 }

--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -442,7 +442,7 @@ public class MesosNimbus implements INimbus {
         _offers.remove(offerID);
       }
 
-      String logviewerZKNodeName = String.format("/logviewers/%s", nodeId));
+      String logviewerZKNodeName = String.format("/logviewers/%s", nodeId);
       _zkClient.createNode(logviewerZKNodeName);
       LOG.info("launchLogviewer: Updating logviewer state in zk: {}", logviewerZKNodeName);
     }

--- a/storm/src/main/storm/mesos/NimbusMesosScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusMesosScheduler.java
@@ -122,7 +122,7 @@ public class NimbusMesosScheduler implements Scheduler {
   private void updateLogviewerState(TaskStatus status) {
     String taskId = status.getTaskId().getValue();
     if (!taskId.contains(MesosCommon.MESOS_COMPONENT_ID_DELIMITER)) {
-      LOG.error("updateLogviewerState: taskId for logviewer, {}, isn't formatted correctly", taskId);
+      LOG.error("updateLogviewerState: taskId for logviewer, {}, isn't formatted correctly so ignoring task update", taskId);
       return;
     }
     String nodeId = taskId.split("\\" + MesosCommon.MESOS_COMPONENT_ID_DELIMITER)[1];
@@ -138,6 +138,7 @@ public class NimbusMesosScheduler implements Scheduler {
         checkRunningLogviewerState(logviewerZKPath);
         return;
       case TASK_LOST:
+        // this status update can be triggered by the explicit kill and isn't terminal, do not kill again
         break;
       default:
         // explicitly kill the logviewer task to ensure logviewer is terminated

--- a/storm/src/main/storm/mesos/NimbusMesosScheduler.java
+++ b/storm/src/main/storm/mesos/NimbusMesosScheduler.java
@@ -28,6 +28,7 @@ import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import storm.mesos.schedulers.StormSchedulerImpl;
 import storm.mesos.util.ZKClient;
 
 import java.util.List;

--- a/storm/src/main/storm/mesos/schedulers/SchedulerUtils.java
+++ b/storm/src/main/storm/mesos/schedulers/SchedulerUtils.java
@@ -91,9 +91,9 @@ public class SchedulerUtils {
    * @param topologyId ID of topology requiring assignment
    * @return boolean value indicating supervisor existence
    */
-  public static boolean supervisorExists(String offerHost, Collection<SupervisorDetails> existingSupervisors,
+  public static boolean supervisorExists(String frameworkName, String offerHost, Collection<SupervisorDetails> existingSupervisors,
                                    String topologyId) {
-    String expectedSupervisorId = MesosCommon.supervisorId(offerHost, topologyId);
+    String expectedSupervisorId = MesosCommon.supervisorId(frameworkName, offerHost, topologyId);
     for (SupervisorDetails supervisorDetail : existingSupervisors) {
       if (supervisorDetail.getId().equals(expectedSupervisorId)) {
         return true;

--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -70,6 +70,14 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
     mesosStormConf = conf;
   }
 
+  public void setOffersSuppressed() {
+    offersSuppressed = true;
+  }
+
+  public void unsetOffersSuppressed() {
+    offersSuppressed = false;
+  }
+
   private List<MesosWorkerSlot> getMesosWorkerSlots(Map<String, AggregatedOffers> aggregatedOffersPerNode,
                                                     Collection<String> nodesWithExistingSupervisors,
                                                     TopologyDetails topologyDetails) {
@@ -165,7 +173,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
       if (!offersSuppressed) {
         log.info("(SUPPRESS OFFERS) We don't have any topologies that need assignments, but offers are still flowing. Suppressing offers.");
         driver.suppressOffers();
-        offersSuppressed = true;
+        setOffersSuppressed();
       }
       return new ArrayList<>();
     }
@@ -176,7 +184,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
       if (offersSuppressed) {
         log.info("(REVIVE OFFERS) We have topologies that need assignments, but offers are currently suppressed. Reviving offers.");
         driver.reviveOffers();
-        offersSuppressed = false;
+        unsetOffersSuppressed();
       }
       // Note: We still have the offersLock at this point, so we return the empty ArrayList so that we can release the lock and acquire new offers
       return new ArrayList<>();

--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -204,7 +204,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
 
       Set<String> nodesWithExistingSupervisors = new HashSet<>();
       for (String currentNode : aggregatedOffersPerNode.keySet()) {
-        if (SchedulerUtils.supervisorExists(currentNode, existingSupervisors, currentTopology)) {
+        if (SchedulerUtils.supervisorExists(MesosCommon.getMesosFrameworkName(mesosStormConf), currentNode, existingSupervisors, currentTopology)) {
           nodesWithExistingSupervisors.add(currentNode);
         }
       }

--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -170,14 +170,14 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
     }
     if (offersRequestTracker.isEmpty()) {
       if (!offers.isEmpty()) {
-        log.info("Declining all offers that are currently buffered because no topologies or tasks need assignments. Declined offer ids: {}", offerMapKeySetToString(offers));
+        log.info("Declining all offers that are currently buffered because no topologies nor tasks need assignments. Declined offer ids: {}", offerMapKeySetToString(offers));
         for (Protos.OfferID offerId : offers.keySet()) {
           driver.declineOffer(offerId);
         }
         offers.clear();
       }
       if (!offersSuppressed) {
-        log.info("(SUPPRESS OFFERS) We don't have any topologies or tasks that need assignments, but offers are still flowing. Suppressing offers.");
+        log.info("(SUPPRESS OFFERS) We don't have any topologies nor tasks that need assignments, but offers are still flowing. Suppressing offers.");
         driver.suppressOffers();
         offersSuppressed = true;
       }
@@ -188,7 +188,7 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
 
     if (offers.isEmpty()) {
       if (offersSuppressed) {
-        log.info("(REVIVE OFFERS) We have topologies or sidecar tasks that need assignments, but offers are currently suppressed. Reviving offers.");
+        log.info("(REVIVE OFFERS) We have topologies or tasks that need assignments, but offers are currently suppressed. Reviving offers.");
         driver.reviveOffers();
         offersSuppressed = false;
       }

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -105,7 +105,7 @@ public class MesosCommon {
   }
 
   public static String supervisorId(String nodeid, String topologyId) {
-    return String.format("%s-%s", nodeid, topologyId);
+    return String.format("%s|%s", nodeid, topologyId);
   }
 
   public static boolean autoStartLogViewer(Map conf) {

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -60,7 +60,7 @@ public class MesosCommon {
   public static final String SUPERVISOR_ID = "supervisorid";
   public static final String ASSIGNMENT_ID = "assignmentid";
   public static final String DEFAULT_WORKER_NAME_PREFIX_DELIMITER = "_";
-  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = " | ";
+  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = "|";
 
   public static String getNimbusHost(Map mesosStormConf) throws UnknownHostException {
     Optional<String> nimbusHostFromConfig =  Optional.fromNullable((String) mesosStormConf.get(Config.NIMBUS_HOST));
@@ -105,7 +105,7 @@ public class MesosCommon {
   }
 
   public static String supervisorId(String nodeid, String topologyId) {
-    return String.format("%s|%s", nodeid, topologyId);
+    return String.format("%s%s%s", nodeid, DEFAULT_MESOS_COMPONENT_NAME_DELIMITER, topologyId);
   }
 
   public static boolean autoStartLogViewer(Map conf) {

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -24,6 +24,7 @@ import org.apache.storm.scheduler.TopologyDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import storm.mesos.MesosNimbus;
 import storm.mesos.resources.AggregatedOffers;
 
 import java.net.InetAddress;
@@ -60,7 +61,12 @@ public class MesosCommon {
   public static final String SUPERVISOR_ID = "supervisorid";
   public static final String ASSIGNMENT_ID = "assignmentid";
   public static final String DEFAULT_WORKER_NAME_PREFIX_DELIMITER = "_";
-  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = "|";
+  public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = " | ";
+  public static final String MESOS_COMPONENT_ID_DELIMITER = "|";
+
+  public static String getMesosFrameworkName(Map mesosStormConf) {
+    return Optional.fromNullable((String) mesosStormConf.get(MesosNimbus.CONF_MESOS_FRAMEWORK_NAME)).or("Storm!!!");
+  }
 
   public static String getNimbusHost(Map mesosStormConf) throws UnknownHostException {
     Optional<String> nimbusHostFromConfig =  Optional.fromNullable((String) mesosStormConf.get(Config.NIMBUS_HOST));
@@ -104,8 +110,8 @@ public class MesosCommon {
     return String.format("%s-%d-%s", nodeid, port, timestampMillis());
   }
 
-  public static String supervisorId(String nodeid, String topologyId) {
-    return String.format("%s%s%s", nodeid, DEFAULT_MESOS_COMPONENT_NAME_DELIMITER, topologyId);
+  public static String supervisorId(String frameworkName, String nodeid, String topologyId) {
+    return String.format("%s%s%s%s%s", frameworkName, MESOS_COMPONENT_ID_DELIMITER, nodeid, MESOS_COMPONENT_ID_DELIMITER, topologyId);
   }
 
   public static boolean autoStartLogViewer(Map conf) {

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -64,6 +64,9 @@ public class MesosCommon {
   public static final String DEFAULT_MESOS_COMPONENT_NAME_DELIMITER = " | ";
   public static final String MESOS_COMPONENT_ID_DELIMITER = "|";
 
+  public static final String LOGVIEWER_OFFERS_REQUEST_KEY = "logviewer";
+  public static final String TOPOLOGIES_OFFERS_REQUEST_KEY = "topologies";
+
   public static String getMesosFrameworkName(Map mesosStormConf) {
     return Optional.fromNullable((String) mesosStormConf.get(MesosNimbus.CONF_MESOS_FRAMEWORK_NAME)).or("Storm!!!");
   }

--- a/storm/src/main/storm/mesos/util/ZKClient.java
+++ b/storm/src/main/storm/mesos/util/ZKClient.java
@@ -1,0 +1,115 @@
+package storm.mesos.util;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.framework.api.BackgroundCallback;
+import org.apache.curator.framework.api.CuratorEvent;
+import org.apache.curator.framework.api.CuratorListener;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by rtang on 7/21/17.
+ */
+public class ZKClient {
+  CuratorFramework _client;
+  public static final Logger LOG = LoggerFactory.getLogger(ZKClient.class);
+  private static final int BASE_SLEEP_TIME_MS = 1000;
+  private static final int MAX_RETRIES = 3;
+
+  public ZKClient() {
+    ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_RETRIES);
+    _client = CuratorFrameworkFactory.newClient("localhost:2181", retryPolicy);
+    _client.start();
+  }
+
+  public ZKClient(String connectionString) {
+    LOG.info("Attempting to connect to following ZooKeeper servers: {}", connectionString);
+    ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_RETRIES);
+    _client = CuratorFrameworkFactory.newClient(connectionString, retryPolicy);
+    _client.start();
+  }
+
+  public ZKClient(String connectionString, int connectionTimeout, int sessionTimeout) {
+    LOG.info("Attempting to connect to following ZooKeeper servers: {}", connectionString);
+    ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_RETRIES);
+    _client = CuratorFrameworkFactory.builder()
+                                     .connectString(connectionString)
+                                     .retryPolicy(retryPolicy)
+                                     .connectionTimeoutMs(connectionTimeout)
+                                     .sessionTimeoutMs(sessionTimeout)
+                                     .build();
+    _client.start();
+  }
+
+  public boolean createNode(String path, String data) {
+    try {
+      _client.create().creatingParentsIfNeeded().forPath(path, data.getBytes());
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public boolean createNode(String path) {
+    try {
+      // default payload of byte[0]
+      _client.create().creatingParentsIfNeeded().forPath(path);
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public void deleteNode(String path) {
+    try {
+      // the delete is guaranteed even if initial failure, curator will attempt to delete in background until successful
+      _client.delete().guaranteed().forPath(path);
+    } catch (Exception e) {
+      // swallow exception because delete is guaranteed
+    }
+  }
+
+  public boolean updateNodeData(String path, String data) {
+    try {
+      _client.setData().forPath(path, data.getBytes());
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public String getNodeData(String path) {
+    byte[] rawData = null;
+    try {
+      rawData = _client.getData().forPath(path);
+      return new String(rawData, "UTF-8");
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return "";
+    }
+  }
+
+  public boolean nodeExists(String path) {
+    try {
+      Stat stat = _client.checkExists().forPath(path);
+      if (stat == null) {
+        return false;
+      }
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public void close() {
+    _client.close();
+  }
+}

--- a/storm/src/main/storm/mesos/util/ZKClient.java
+++ b/storm/src/main/storm/mesos/util/ZKClient.java
@@ -11,6 +11,8 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 /**
  * ZKClient allows you to interact with ZooKeeper. Primarily used for tracking logviewer state on hosts thus far but
  * can be used to track any metadata needed in the future.
@@ -87,15 +89,24 @@ public class ZKClient {
     }
   }
 
-  public String getNodeData(String path) {
+  public boolean updateNodeData(String path, byte[] data) {
+    try {
+      _client.setData().forPath(path, data);
+      return true;
+    } catch (Exception e) {
+      LOG.error(e.toString());
+      return false;
+    }
+  }
+
+  public byte[] getNodeData(String path) {
     byte[] rawData = null;
     try {
       rawData = _client.getData().forPath(path);
-      return new String(rawData, "UTF-8");
     } catch (Exception e) {
       LOG.error(e.toString());
-      return "";
     }
+    return rawData;
   }
 
   public boolean nodeExists(String path) {
@@ -109,6 +120,16 @@ public class ZKClient {
       LOG.error(e.toString());
       return false;
     }
+  }
+
+  public List<String> getChildren(String path) {
+    List<String> children = null;
+    try {
+      children = _client.getChildren().forPath(path);
+    } catch (Exception e) {
+      LOG.error(e.toString());
+    }
+    return children;
   }
 
   public void close() {

--- a/storm/src/main/storm/mesos/util/ZKClient.java
+++ b/storm/src/main/storm/mesos/util/ZKClient.java
@@ -12,8 +12,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Created by rtang on 7/21/17.
+ * ZKClient allows you to interact with ZooKeeper. Primarily used for tracking logviewer state on hosts thus far but
+ * can be used to track any metadata needed in the future.
  */
+
 public class ZKClient {
   CuratorFramework _client;
   public static final Logger LOG = LoggerFactory.getLogger(ZKClient.class);

--- a/storm/src/test/storm/mesos/MesosCommonTest.java
+++ b/storm/src/test/storm/mesos/MesosCommonTest.java
@@ -155,10 +155,11 @@ public class MesosCommonTest {
 
   @Test
   public void testSupervisorId() throws Exception {
+    String frameworkName = "Storm!!!";
     String nodeid = "nodeID1";
     String topologyid = "t1";
-    String result = MesosCommon.supervisorId(nodeid, topologyid);
-    String expectedResult = nodeid + "|" + topologyid;
+    String result = MesosCommon.supervisorId(frameworkName, nodeid, topologyid);
+    String expectedResult = frameworkName + "|" + nodeid + "|" + topologyid;
     assertEquals(result, expectedResult);
   }
 

--- a/storm/src/test/storm/mesos/MesosCommonTest.java
+++ b/storm/src/test/storm/mesos/MesosCommonTest.java
@@ -158,7 +158,7 @@ public class MesosCommonTest {
     String nodeid = "nodeID1";
     String topologyid = "t1";
     String result = MesosCommon.supervisorId(nodeid, topologyid);
-    String expectedResult = nodeid + "-" + topologyid;
+    String expectedResult = nodeid + "|" + topologyid;
     assertEquals(result, expectedResult);
   }
 

--- a/storm/src/test/storm/mesos/MesosNimbusTest.java
+++ b/storm/src/test/storm/mesos/MesosNimbusTest.java
@@ -180,7 +180,7 @@ public class MesosNimbusTest {
 
   private String getTopologyIdFromTaskName(String taskName) {
     String info[] = taskName.split("\\|");
-    return info[1];
+    return info[2];
   }
 
   private Map<String, List<Protos.TaskInfo>> getTopologyIDtoTaskInfoMap(List<Protos.TaskInfo> taskInfoList) {

--- a/storm/src/test/storm/mesos/ZKClientTest.java
+++ b/storm/src/test/storm/mesos/ZKClientTest.java
@@ -1,5 +1,6 @@
 package storm.mesos;
 
+import org.apache.mesos.Protos;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.junit.After;
@@ -7,6 +8,8 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import storm.mesos.util.ZKClient;
 import org.apache.curator.test.TestingServer;
+
+import java.util.List;
 
 public class ZKClientTest {
   /**
@@ -69,7 +72,7 @@ public class ZKClientTest {
     success = target.createNode(pathName, initialString);
     assertTrue("Couldn't create node", success);
 
-    String returnedString = target.getNodeData(pathName);
+    String returnedString = new String(target.getNodeData(pathName));
     assertTrue("Data retrieved doesn't match initial data", initialString.equals(returnedString));
 
     target.deleteNode(pathName);
@@ -89,7 +92,7 @@ public class ZKClientTest {
     success = target.updateNodeData(pathName, updatedString);
     assertTrue("Couldn't update node data", success);
 
-    String returnedString = target.getNodeData(pathName);
+    String returnedString = new String(target.getNodeData(pathName));
     assertTrue("Data retrieved doesn't match updated data", updatedString.equals(returnedString));
 
     target.deleteNode(pathName);
@@ -119,6 +122,78 @@ public class ZKClientTest {
 
     target.deleteNode(parentPath);
     assertFalse("Parent node unsuccessfully deleted", target.nodeExists(parentPath));
+  }
+
+  @Test
+  public void testGetChildrenOfParentNode() {
+    boolean success = false;
+    String parentPath = "/parent";
+    String nestedPathOne = "/parent/childOne";
+    String nestedPathTwo = "/parent/childTwo";
+
+    success = target.createNode(nestedPathOne);
+    assertTrue("Failed to create parent and child node", success);
+
+    assertTrue("Parent node was not created", target.nodeExists(parentPath));
+
+    success = target.createNode(nestedPathTwo);
+    assertTrue("Failed to create second node under parent", success);
+
+    List<String> childrenPaths = target.getChildren(parentPath);
+    assertTrue("childOne path not successfully retrieved", childrenPaths.contains(nestedPathOne.split("\\/")[2]));
+    assertTrue("childTwo path not successfully retrieved", childrenPaths.contains(nestedPathTwo.split("\\/")[2]));
+    assertFalse("Random path retrieved when not created", childrenPaths.contains("random"));
+
+    target.deleteNode(nestedPathOne);
+    assertFalse("First child node unsuccessfully deleted", target.nodeExists(nestedPathOne));
+
+    target.deleteNode(nestedPathTwo);
+    assertFalse("Second child node unsuccessfully deleted", target.nodeExists(nestedPathTwo));
+
+    target.deleteNode(parentPath);
+    assertFalse("Parent node unsuccessfully deleted", target.nodeExists(parentPath));
+  }
+
+  @Test
+  public void testTrackingTastStatusData() {
+    boolean success = false;
+    String path = "/taskStatus";
+    String id = "id";
+    Protos.TaskID taskId = Protos.TaskID.newBuilder()
+                                        .setValue(id)
+                                        .build();
+    Protos.TaskStatus status = Protos.TaskStatus.newBuilder()
+                                                .setTaskId(taskId)
+                                                .setState(Protos.TaskState.TASK_RUNNING)
+                                                .build();
+
+    success = target.createNode(path);
+    assertTrue("Failed to create node at specified path", success);
+
+    success = target.updateNodeData(path, id);
+    assertTrue("Failed to update node data at specified path", success);
+
+    Protos.TaskID taskIdClone = Protos.TaskID.newBuilder()
+                                             .setValue(new String(target.getNodeData(path)))
+                                             .build();
+    Protos.TaskStatus statusClone = Protos.TaskStatus.newBuilder()
+                                                .setTaskId(taskIdClone)
+                                                .setState(Protos.TaskState.TASK_RUNNING)
+                                                .build();
+
+    Protos.TaskID taskIdFake = Protos.TaskID.newBuilder()
+            .setValue("fake")
+            .build();
+    Protos.TaskStatus statusFake = Protos.TaskStatus.newBuilder()
+            .setTaskId(taskIdFake)
+            .setState(Protos.TaskState.TASK_RUNNING)
+            .build();
+
+    assertTrue("TaskStatus objects stored in ZooKeeper do not match existing ones", status.equals(statusClone));
+    assertFalse("Fake TaskStatus objects match the ones stored in ZooKeeper", status.equals(statusFake));
+
+    target.deleteNode(path);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(path));
   }
 
   @After

--- a/storm/src/test/storm/mesos/ZKClientTest.java
+++ b/storm/src/test/storm/mesos/ZKClientTest.java
@@ -1,0 +1,131 @@
+package storm.mesos;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.data.Stat;
+import org.junit.After;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import storm.mesos.util.ZKClient;
+import org.apache.curator.test.TestingServer;
+
+/**
+ * Created by rtang on 7/21/17.
+ */
+public class ZKClientTest {
+  /**
+   * Testing target.
+   */
+  private final ZKClient target;
+
+  /**
+   * Setup testing target & sample data.
+   */
+  public ZKClientTest() {
+    String connString = "localhost:2181";
+    try {
+      TestingServer server = new TestingServer(true);
+      connString = server.getConnectString();
+    } catch (Exception e) {
+      assertTrue("Couldn't create test server", false);
+    }
+    target = new ZKClient(connString);
+  }
+
+  @Test
+  public void testCreateNodeThenDelete() {
+    boolean success = false;
+    String pathName = "/test1";
+
+    success = target.createNode(pathName);
+    assertTrue("Couldn't create node", success);
+
+    target.deleteNode(pathName);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCreateNodeCheckExistenceThenDelete() {
+    boolean success = false;
+    String pathName = "/test2";
+
+    success = target.createNode(pathName);
+    assertTrue("Couldn't create node", success);
+
+    assertTrue("Node created but doesn't exist", target.nodeExists(pathName));
+
+    target.deleteNode(pathName);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCheckExistenceOfNonexistentNode() {
+    String pathName = "/test3";
+    assertFalse("Nonexistent node exists for some reason", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCreateNodeGetDataThenDelete() {
+    boolean success = false;
+    String pathName = "/test4";
+    String initialString = "test";
+
+    success = target.createNode(pathName, initialString);
+    assertTrue("Couldn't create node", success);
+
+    String returnedString = target.getNodeData(pathName);
+    assertTrue("Data retrieved doesn't match initial data", initialString.equals(returnedString));
+
+    target.deleteNode(pathName);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCreateNodeUpdateDataThenDelete() {
+    boolean success = false;
+    String pathName = "/test5";
+    String initialString = "test";
+
+    success = target.createNode(pathName, initialString);
+    assertTrue("Couldn't create node", success);
+
+    String updatedString = "updated";
+    success = target.updateNodeData(pathName, updatedString);
+    assertTrue("Couldn't update node data", success);
+
+    String returnedString = target.getNodeData(pathName);
+    assertTrue("Data retrieved doesn't match updated data", updatedString.equals(returnedString));
+
+    target.deleteNode(pathName);
+    assertFalse("Node unsuccessfully deleted", target.nodeExists(pathName));
+  }
+
+  @Test
+  public void testCreateNestedNodeThenDelete() {
+    boolean success = false;
+    String parentPath = "/parent";
+    String nestedPathOne = "/parent/childOne";
+    String nestedPathTwo = "/parent/childTwo";
+
+    success = target.createNode(nestedPathOne);
+    assertTrue("Failed to create parent and child node", success);
+
+    assertTrue("Parent node was not created", target.nodeExists(parentPath));
+
+    success = target.createNode(nestedPathTwo);
+    assertTrue("Failed to create second node under parent", success);
+
+    target.deleteNode(nestedPathOne);
+    assertFalse("First child node unsuccessfully deleted", target.nodeExists(nestedPathOne));
+
+    target.deleteNode(nestedPathTwo);
+    assertFalse("Second child node unsuccessfully deleted", target.nodeExists(nestedPathTwo));
+
+    target.deleteNode(parentPath);
+    assertFalse("Parent node unsuccessfully deleted", target.nodeExists(parentPath));
+  }
+
+  @After
+  public void closeConnection() {
+    target.close();
+  }
+}

--- a/storm/src/test/storm/mesos/ZKClientTest.java
+++ b/storm/src/test/storm/mesos/ZKClientTest.java
@@ -8,9 +8,6 @@ import static org.junit.Assert.*;
 import storm.mesos.util.ZKClient;
 import org.apache.curator.test.TestingServer;
 
-/**
- * Created by rtang on 7/21/17.
- */
 public class ZKClientTest {
   /**
    * Testing target.

--- a/storm/src/test/storm/mesos/schedulers/SchedulerUtilsTest.java
+++ b/storm/src/test/storm/mesos/schedulers/SchedulerUtilsTest.java
@@ -54,11 +54,12 @@ public class SchedulerUtilsTest {
   public void testSupervisorExists() throws Exception {
     Collection<SupervisorDetails> existingSupervisors = new ArrayList<>();
     String hostName = "host1.east";
+    String frameworkName = "Storm!!!";
 
-    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(hostName, "test-topology1-65-1442255385"), hostName));
-    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(hostName, "test-topology10-65-1442255385"), hostName));
+    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(frameworkName, hostName, "test-topology1-65-1442255385"), hostName));
+    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(frameworkName, hostName, "test-topology10-65-1442255385"), hostName));
 
-    assertEquals(true, SchedulerUtils.supervisorExists(hostName, existingSupervisors, "test-topology1-65-1442255385"));
-    assertEquals(false, SchedulerUtils.supervisorExists(hostName, existingSupervisors, "test-topology2-65-1442255385"));
+    assertEquals(true, SchedulerUtils.supervisorExists(frameworkName, hostName, existingSupervisors, "test-topology1-65-1442255385"));
+    assertEquals(false, SchedulerUtils.supervisorExists(frameworkName, hostName, existingSupervisors, "test-topology2-65-1442255385"));
   }
 }

--- a/storm/src/test/storm/mesos/schedulers/StormSchedulerImplTest.java
+++ b/storm/src/test/storm/mesos/schedulers/StormSchedulerImplTest.java
@@ -68,6 +68,7 @@ public class StormSchedulerImplTest {
   private SchedulerDriver driver;
   private final String sampleTopologyId = "test-topology1-65-1442255385";
   private final String sampleHost = "host1.example.org";
+  private final String sampleFrameworkName = "Storm!!!";
   private final int samplePort = 3100;
 
   private Cluster getSpyCluster() {
@@ -158,8 +159,8 @@ public class StormSchedulerImplTest {
     topologiesMissingAssignments.add("test-topology1-65-1442255385");
 
     existingSupervisors = new ArrayList<>();
-    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(sampleHost, "test-topology1-65-1442255385"), sampleHost, null, null));
-    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(sampleHost, "test-topology10-65-1442255385"), sampleHost, null, null));
+    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(sampleFrameworkName, sampleHost, "test-topology1-65-1442255385"), sampleHost, null, null));
+    existingSupervisors.add(new SupervisorDetails(MesosCommon.supervisorId(sampleFrameworkName, sampleHost, "test-topology10-65-1442255385"), sampleHost, null, null));
 
     topologyMap = new HashMap<>();
     topologyMap.put(sampleTopologyId, TestUtils.constructTopologyDetails(sampleTopologyId, 1, 0.1, 100));


### PR DESCRIPTION
#### Notes
- Automated logviewer launch on any worker hosts running Storm bits (1.x specific)
- State of these logviewer daemons are tracked per host by stuffing state into ZooKeeper
- Reconciliation is also implemented to ensure that logviewers are brought back alive if ever killed.

#### ZKClient.java
- Wrapper around Apache Curator in order to interact with ZK
- Can create, delete, and check for existence of nodes in ZK
- Used to track which hosts are running logviewer daemons by tracking that state into ZK
- Junit tests are written for this class

#### MesosNimbus.java
- Added TimerTask to perform implicit reconciliation every 5 minutes
  - Implicit reconciliation reconciles that state of every running task between the framework scheduler and master (sends update of task status to *statusUpdate* method in *NimbusMesosScheduler*)
- *launchLogviewer* method called in *allSlotsAvailableForScheduling* loops through the *existingSupervisors* and schedules the logviewer daemon as Mesos tasks based on the offers available on each host
  - Checks ZK if logviewer already running on the host which the supervisor is running on, as such, ensures that logviewer only runs on hosts with Storm bits

#### StormSchedulerImpl.java
- Added an *offersRequestTracker* that tracks if any storm tasks (topologies) or sidecar tasks need offers. This ensures that offers are only suppressed when no tasks need them.

#### NimbusMesosScheduler.java
- Updated *statusUpdate* method to look for logviewer tasks to check if they need to be relaunched
- *updateLogviewerState* method updates the state of the logviewer task in ZK if needed
  - *checkRunningLogviewerState* method checks if a running Mesos tasks exists for logviewer that isn't tracked in ZK and updates ZK state if necessary

#### MesosCommon.java
- Added *getMesosFrameworkName* as an utility to get the framework name from the storm.yaml
- Modified *supervisorId* method to format the ID with the framework name
