### PR TITLE
Shuffle offers before turning them into worker slots.

### DIFF
--- a/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
+++ b/storm/src/main/storm/mesos/schedulers/StormSchedulerImpl.java
@@ -106,7 +106,9 @@ public class StormSchedulerImpl implements IScheduler, IMesosStormScheduler {
 
     do {
       slotFound = false;
-      for (String currentNode : aggregatedOffersPerNode.keySet()) {
+      List<String> hostsWithOffers = new ArrayList<String>(aggregatedOffersPerNode.keySet());
+      Collections.shuffle(hostsWithOffers);
+      for (String currentNode : hostsWithOffers) {
         AggregatedOffers aggregatedOffers = aggregatedOffersPerNode.get(currentNode);
 
         boolean supervisorExists = nodesWithExistingSupervisors.contains(currentNode);


### PR DESCRIPTION
We've found that with few topologies running and limited resource demand, the iteration over the list of hosts with offers results in all worker slots being assigned to the same physical machine more often than not. This is less than ideal.

This change is to shuffle the offers before we make any slots on them, so as to distribute things more evenly.