### PR TITLE
Optionally Launch Logviewer with Sidecar Pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ For local development and familiarizing yourself with Storm/Mesos, please see th
 * `mesos.framework.principal`: Framework principal to use to register with Mesos
 * `mesos.framework.secret.file`:  Location of file that contains the principal's secret. Secret cannot end with a NL.
 * `mesos.prefer.reserved.resources`: Prefer reserved resources over unreserved (i.e., `"*"` role). Defaults to "true".
-* `supervisor.autostart.logviewer`: Default is true. If you disable the logviewer, you may want to
-  subtract 128*1.2 from `topology.mesos.executor.mem.mb` (depending on your settings).
+* `mesos.logviewer.sidecar.enabled`: Default is "true". If you disable this setting, you will want to launch a logviewer
+  process on each worker and nimbus host under supervision if you want to view logs in the Storm UI.
 
 ## Resource configuration
 

--- a/storm.yaml
+++ b/storm.yaml
@@ -28,7 +28,7 @@ logviewer.port: 8000
 logviewer.childopts: "-Xmx128m"
 logviewer.cleanup.age.mins: 10080
 logviewer.appender.name: "A1"
-supervisor.autostart.logviewer: true
+mesos.logviewer.sidecar.enabled: true
 
 # Use the public Mesosphere Storm build
 # Please note that it won't work with other distributions.

--- a/storm/src/main/storm/mesos/MesosSupervisor.java
+++ b/storm/src/main/storm/mesos/MesosSupervisor.java
@@ -167,7 +167,7 @@ public class MesosSupervisor implements ISupervisor {
   }
 
   protected boolean startLogViewer(Map conf) {
-    return MesosCommon.autoStartLogViewer(conf);
+    return MesosCommon.enabledLogviewerSidecar(conf);
   }
 
   class StormExecutor implements Executor {

--- a/storm/src/main/storm/mesos/util/MesosCommon.java
+++ b/storm/src/main/storm/mesos/util/MesosCommon.java
@@ -43,7 +43,7 @@ public class MesosCommon {
   public static final String SUICIDE_CONF = "mesos.supervisor.suicide.inactive.timeout.secs";
   public static final String SUPERVISOR_STORM_LOCAL_DIR_CONF = "mesos.supervisor.storm.local.dir";
   public static final String CONF_MESOS_ROLE = "mesos.framework.role";
-  public static final String AUTO_START_LOGVIEWER_CONF = "supervisor.autostart.logviewer";
+  public static final String LOGVIEWER_SIDECAR_ENABLED = "mesos.logviewer.sidecar.enabled";
   // Should we prefix the Worker Task ID with a configurable string (as well as the topology name)?
   public static final String WORKER_NAME_PREFIX = "topology.mesos.worker.prefix";
   public static final String WORKER_NAME_PREFIX_DELIMITER = "topology.mesos.worker.prefix.delimiter";
@@ -117,8 +117,8 @@ public class MesosCommon {
     return String.format("%s%s%s%s%s", frameworkName, MESOS_COMPONENT_ID_DELIMITER, nodeid, MESOS_COMPONENT_ID_DELIMITER, topologyId);
   }
 
-  public static boolean autoStartLogViewer(Map conf) {
-    return Optional.fromNullable((Boolean) conf.get(AUTO_START_LOGVIEWER_CONF)).or(true);
+  public static boolean enabledLogviewerSidecar(Map conf) {
+    return Optional.fromNullable((Boolean) conf.get(LOGVIEWER_SIDECAR_ENABLED)).or(true);
   }
 
   public static int portFromTaskId(String taskId) {

--- a/storm/src/test/storm/mesos/MesosCommonTest.java
+++ b/storm/src/test/storm/mesos/MesosCommonTest.java
@@ -171,10 +171,10 @@ public class MesosCommonTest {
   @Test
   public void testStartLogViewer() throws Exception {
     // Test the default (true)
-    boolean result = MesosCommon.autoStartLogViewer(conf);
+    boolean result = MesosCommon.enabledLogviewerSidecar(conf);
     assertTrue(result);
-    conf.put(MesosCommon.AUTO_START_LOGVIEWER_CONF, false);
-    result = MesosCommon.autoStartLogViewer(conf);
+    conf.put(MesosCommon.LOGVIEWER_SIDECAR_ENABLED, false);
+    result = MesosCommon.enabledLogviewerSidecar(conf);
     assertTrue(!result);
   }
 


### PR DESCRIPTION
Changes by @changreytang allow launching of logviewer processes to be launched dynamically when either the first supervisor on a host is launched or the logviewer container dies and sends a task update to Mesos Nimbus. These changes were added in PR #212 and PR #228. In the event that a user does not wish to launch the logviewer in this fashion, they are now able to opt out.

This PR has two commits:
* Remove defunct `supervisor.autostart.logviewer` configuration option and refactor the associated code to instead work on `mesos.logviewer.sidecar.enabled`.
* Add checks around the logic that controls when we launch a logviewer so that when opting out of the sidecar pattern, we don't launch the sidecars.