### PR TITLE
Fix #222

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ script:
 matrix:
   fast_finish: true
   include:
-  - env: STORM_RELEASE="1.0.3" MESOS_RELEASE="1.1.0"
-  - env: STORM_RELEASE="1.0.3" MESOS_RELEASE="0.28.2"
+  - env: STORM_RELEASE="1.0.4" MESOS_RELEASE="1.1.0"
+  - env: STORM_RELEASE="1.0.4" MESOS_RELEASE="0.28.2"
 before_deploy:
 - travis_retry make images
 - travis_retry make images JAVA_PRODUCT_VERSION=8

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <!-- These are used by bin/build-release.sh to determine which versions
          should be used by default if MESOS_RELEASE and/or STORM_RELEASE
          are not set. -->
-    <storm.default.version>1.0.3</storm.default.version>
+    <storm.default.version>1.0.4</storm.default.version>
     <mesos.default.version>0.27.0</mesos.default.version>
     <mesos.version>0.27.0</mesos.version>
   </properties>
@@ -41,7 +41,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <storm.version>1.0.3</storm.version>
+        <storm.version>1.0.4</storm.version>
         <shim>storm-shim-1x</shim>
         <snakeyaml.scope>compile</snakeyaml.scope>
       </properties>

--- a/storm/src/test/storm/mesos/MesosCommonTest.java
+++ b/storm/src/test/storm/mesos/MesosCommonTest.java
@@ -41,6 +41,7 @@ public class MesosCommonTest {
   private Map conf;
   private TopologyDetails info;
   private String topologyName = "t_name";
+  private String topologyOwner = "t_owner";
   private static final double DELTA_FOR_DOUBLE_COMPARISON = 0.0001;
   private final MesosNimbus mesosNimbus;
 
@@ -61,7 +62,7 @@ public class MesosCommonTest {
   @Before
   public void initTest() {
     initConf();
-    info = new TopologyDetails("t1", conf, new StormTopology(), 1);
+    info = new TopologyDetails("t1", conf, new StormTopology(), 1, topologyOwner);
   }
 
   @Test
@@ -86,7 +87,7 @@ public class MesosCommonTest {
     // Test explicit value of prefix
     String prefix = ":(";
     conf.put(MesosCommon.WORKER_NAME_PREFIX, prefix);
-    info = new TopologyDetails("t2", conf, new StormTopology(), 1);
+    info = new TopologyDetails("t2", conf, new StormTopology(), 1, topologyOwner);
     result = MesosCommon.getWorkerPrefix(conf, info);
     expectedResult = prefix + topologyName + MesosCommon.DEFAULT_WORKER_NAME_PREFIX_DELIMITER;
     assertEquals(result, expectedResult);
@@ -95,14 +96,14 @@ public class MesosCommonTest {
     // Test explicit value of delimiter
     String delimiter = ":)";
     conf.put(MesosCommon.WORKER_NAME_PREFIX_DELIMITER, delimiter);
-    info = new TopologyDetails("t3", conf, new StormTopology(), 1);
+    info = new TopologyDetails("t3", conf, new StormTopology(), 1, topologyOwner);
     result = MesosCommon.getWorkerPrefix(conf, info);
     expectedResult = topologyName + delimiter;
     assertEquals(result, expectedResult);
 
     // Test explicit value of prefix and delimiter
     conf.put(MesosCommon.WORKER_NAME_PREFIX, prefix);
-    info = new TopologyDetails("t4", conf, new StormTopology(), 2);
+    info = new TopologyDetails("t4", conf, new StormTopology(), 2, topologyOwner);
     result = MesosCommon.getWorkerPrefix(conf, info);
     expectedResult = prefix + topologyName + delimiter;
     assertEquals(result, expectedResult);
@@ -118,7 +119,7 @@ public class MesosCommonTest {
     assertEquals(result, expectedResult);
 
     // Test explicit value
-    info = new TopologyDetails("t2", conf, new StormTopology(), 2);
+    info = new TopologyDetails("t2", conf, new StormTopology(), 2, topologyOwner);
     String delimiter = "-";
     conf.put(MesosCommon.MESOS_COMPONENT_NAME_DELIMITER, delimiter);
     result = MesosCommon.getMesosComponentNameDelimiter(conf, info);
@@ -126,7 +127,7 @@ public class MesosCommonTest {
     assertEquals(result, expectedResult);
 
     // Test explicit value
-    info = new TopologyDetails("t2", conf, new StormTopology(), 2);
+    info = new TopologyDetails("t2", conf, new StormTopology(), 2, topologyOwner);
     initConf();
     result = MesosCommon.getMesosComponentNameDelimiter(conf, info);
     expectedResult = delimiter;
@@ -135,7 +136,7 @@ public class MesosCommonTest {
     // Test explicit value overridden in topology config
     initConf();
     conf.put(MesosCommon.MESOS_COMPONENT_NAME_DELIMITER, delimiter);
-    info = new TopologyDetails("t3", conf, new StormTopology(), 3);
+    info = new TopologyDetails("t3", conf, new StormTopology(), 3, topologyOwner);
     Map nimbusConf = new HashMap<>();
     nimbusConf.put(MesosCommon.MESOS_COMPONENT_NAME_DELIMITER, "--");
     result = MesosCommon.getMesosComponentNameDelimiter(nimbusConf, info);
@@ -210,7 +211,7 @@ public class MesosCommonTest {
     TestUtils.initializeStormTopologyConfig(topologyConf);
     topologyConf.put("TEST_TOPOLIGY_CONFIG", 3);
     topologyConf.put("TEST_TOPOLOGY_OVERRIDE", 4);
-    TopologyDetails info = new TopologyDetails("t1", topologyConf, new StormTopology(), 2);
+    TopologyDetails info = new TopologyDetails("t1", topologyConf, new StormTopology(), 2, topologyOwner);
     Map result = MesosCommon.getFullTopologyConfig(nimbusConf, info);
     Map expectedResult = new HashMap<>();
     TestUtils.initializeStormTopologyConfig(expectedResult);
@@ -244,7 +245,7 @@ public class MesosCommonTest {
 
     // Test explicit value
     conf.put(MesosCommon.WORKER_CPU_CONF, 1.5);
-    info = new TopologyDetails("t2", conf, new StormTopology(), 2);
+    info = new TopologyDetails("t2", conf, new StormTopology(), 2, topologyOwner);
     result = MesosCommon.topologyWorkerCpu(conf, info);
     expectedResult = 1.5;
     assertEquals(result, expectedResult, DELTA_FOR_DOUBLE_COMPARISON);
@@ -252,7 +253,7 @@ public class MesosCommonTest {
     // Test string passed in
     initConf();
     conf.put(MesosCommon.WORKER_CPU_CONF, "2");
-    info = new TopologyDetails("t3", conf, new StormTopology(), 1);
+    info = new TopologyDetails("t3", conf, new StormTopology(), 1, topologyOwner);
     result = MesosCommon.topologyWorkerCpu(conf, info);
     expectedResult = 1;
     assertEquals(result, expectedResult, DELTA_FOR_DOUBLE_COMPARISON);
@@ -262,7 +263,7 @@ public class MesosCommonTest {
     nimbusConf.put(MesosCommon.WORKER_CPU_CONF, 2);
     initConf();
     conf.put(MesosCommon.WORKER_CPU_CONF, 1.5);
-    info = new TopologyDetails("t4", conf, new StormTopology(), 1);
+    info = new TopologyDetails("t4", conf, new StormTopology(), 1, topologyOwner);
     result = MesosCommon.topologyWorkerCpu(nimbusConf, info);
     expectedResult = 1.5;
     assertEquals(result, expectedResult, DELTA_FOR_DOUBLE_COMPARISON);
@@ -291,14 +292,14 @@ public class MesosCommonTest {
 
     // Test explicit value
     conf.put(MesosCommon.WORKER_MEM_CONF, 1200);
-    info = new TopologyDetails("t2", conf, new StormTopology(), 2);
+    info = new TopologyDetails("t2", conf, new StormTopology(), 2, topologyOwner);
     result = MesosCommon.topologyWorkerMem(conf, info);
     expectedResult = 1200;
     assertEquals(result, expectedResult, DELTA_FOR_DOUBLE_COMPARISON);
 
     // Test string passed in
     conf.put(MesosCommon.WORKER_MEM_CONF, "1200");
-    info = new TopologyDetails("t3", conf, new StormTopology(), 1);
+    info = new TopologyDetails("t3", conf, new StormTopology(), 1, topologyOwner);
     result = MesosCommon.topologyWorkerMem(conf, info);
     expectedResult = 1000;
     assertEquals(result, expectedResult, DELTA_FOR_DOUBLE_COMPARISON);
@@ -307,7 +308,7 @@ public class MesosCommonTest {
     Map nimbusConf = new HashMap<>();
     nimbusConf.put(MesosCommon.WORKER_MEM_CONF, 200);
     conf.put(MesosCommon.WORKER_MEM_CONF, 150);
-    info = new TopologyDetails("t4", conf, new StormTopology(), 1);
+    info = new TopologyDetails("t4", conf, new StormTopology(), 1, topologyOwner);
     result = MesosCommon.topologyWorkerMem(nimbusConf, info);
     expectedResult = 150;
     assertEquals(result, expectedResult, DELTA_FOR_DOUBLE_COMPARISON);

--- a/storm/src/test/storm/mesos/TestUtils.java
+++ b/storm/src/test/storm/mesos/TestUtils.java
@@ -44,7 +44,7 @@ public class TestUtils {
   }
 
   public static TopologyDetails constructTopologyDetails(String topologyName, int numWorkers) {
-    return new TopologyDetails(topologyName, initializeStormTopologyConfig(new HashMap<>()), new StormTopology(), numWorkers);
+    return new TopologyDetails(topologyName, initializeStormTopologyConfig(new HashMap<>()), new StormTopology(), numWorkers, "root");
   }
 
   public static TopologyDetails constructTopologyDetails(String topologyName, int numWorkers, double numCpus, double memSize) {


### PR DESCRIPTION
Update `TopologyDetails` constructor calls to take `owner` parameter, as required for Storm 1.0.4+.

For more context see #222 

This fixes the build.

*NOTE: This breaks backwards compatibility with Storm 1.0.0, 1.0.1, 1.0.2, and 1.0.3.*