### PR TITLE
prevent supervisors from lingering forever

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ script:
 matrix:
   fast_finish: true
   include:
-  - env: STORM_RELEASE="1.0.5" MESOS_RELEASE="1.1.0"
-  - env: STORM_RELEASE="1.0.5" MESOS_RELEASE="0.28.2"
+  - env: STORM_RELEASE="1.0.5" MESOS_RELEASE="1.1.0" STORM_URL="https://github.com/erikdw/storm/releases/download/v1.0.5-storm-mesos1/apache-storm-1.0.5-storm-mesos1.tar.gz"
+  - env: STORM_RELEASE="1.0.5" MESOS_RELEASE="0.28.2" STORM_URL="https://github.com/erikdw/storm/releases/download/v1.0.5-storm-mesos1/apache-storm-1.0.5-storm-mesos1.tar.gz"
 before_deploy:
 - travis_retry make images
 - travis_retry make images JAVA_PRODUCT_VERSION=8

--- a/storm/src/main/storm/mesos/MesosSupervisor.java
+++ b/storm/src/main/storm/mesos/MesosSupervisor.java
@@ -67,7 +67,12 @@ public class MesosSupervisor implements ISupervisor {
 
     try {
       Supervisor supervisor = new Supervisor(conf, null, new MesosSupervisor());
-      supervisor.launchDaemon();
+      // For storm-1.0.5, we use reflection to call the private method, 'launchDaemon', which calls 'launch'
+      Method m = Supervisor.class.getDeclaredMethod("launchDaemon");
+      m.setAccessible(true);
+      m.invoke(supervisor);
+      // Once storm-1.0.6 is available we will remove the code above and just call launchDaemon directly:
+      // supervisor.launchDaemon();
     } catch (Exception e) {
       String msg = String.format("main: Exception: %s", e.getMessage());
       LOG.error(msg);

--- a/storm/src/main/storm/mesos/MesosSupervisor.java
+++ b/storm/src/main/storm/mesos/MesosSupervisor.java
@@ -41,9 +41,12 @@ import storm.mesos.util.MesosCommon;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class MesosSupervisor implements ISupervisor {
   public static final Logger LOG = LoggerFactory.getLogger(MesosSupervisor.class);
@@ -56,17 +59,15 @@ public class MesosSupervisor implements ISupervisor {
   Map _conf;
   // Store state on port assignments arriving from MesosNimbus as task-launching requests.
   private static final TaskAssignments _taskAssignments = TaskAssignments.getInstance();
+  // What is the storm-core supervisor's view of the assigned ports?
+  AtomicReference<Set<Integer>> _supervisorViewOfAssignedPorts = new AtomicReference<Set<Integer>>(new HashSet<Integer>());
 
   public static void main(String[] args) {
     Map<String, Object> conf = ConfigUtils.readStormConfig();
 
     try {
       Supervisor supervisor = new Supervisor(conf, null, new MesosSupervisor());
-
-      // We use reflection to call the private method, 'launchDaemon', which calls 'launch'
-      Method m = Supervisor.class.getDeclaredMethod("launchDaemon");
-      m.setAccessible(true);
-      m.invoke(supervisor);
+      supervisor.launchDaemon();
     } catch (Exception e) {
       String msg = String.format("main: Exception: %s", e.getMessage());
       LOG.error(msg);
@@ -74,12 +75,10 @@ public class MesosSupervisor implements ISupervisor {
     }
   }
 
-  /**
-   * This method is no longer called by the Supervisor since it was refactored from Clojure to Java,
-   * starting in Storm 1.0.3. Now, port changes get captured in calls to 'confirmAssigned'.
-   */
   @Override
   public void assigned(Collection<Integer> ports) {
+    if (ports == null) ports = new HashSet<>();
+    _supervisorViewOfAssignedPorts.set(new HashSet<>(ports));
   }
 
   @Override
@@ -267,7 +266,7 @@ public class MesosSupervisor implements ISupervisor {
       try {
         while (true) {
           long now = System.currentTimeMillis();
-          if (!_taskAssignments.getAssignedPorts().isEmpty()) {
+          if (!_supervisorViewOfAssignedPorts.get().isEmpty()) {
             _lastTime = now;
           }
           if ((now - _lastTime) > 1000L * _timeoutSecs) {


### PR DESCRIPTION
This commit fixes [issue #227](https://github.com/mesos/storm/issues/227).

1. We [revert some of the changes](https://gist.github.com/erikdw/7e35d455de871b73a155745fa4bd2f3f) in this project that were worked on in PR https://github.com/mesos/storm/pull/208.
2. We configure the travis build to use a [custom-built version of storm-1.0.5](https://github.com/erikdw/storm/releases/tag/v1.0.5-storm-mesos1) which includes the fix for [STORM-2690](https://issues.apache.org/jira/browse/STORM-2690), amongst other changes.